### PR TITLE
additional error handling

### DIFF
--- a/src/soliplex/agents/scm/app.py
+++ b/src/soliplex/agents/scm/app.py
@@ -112,7 +112,8 @@ async def get_data(scm: str, repo_name: str, owner: str = None):
 
     issues = await impl.list_issues(repo=repo_name, owner=owner, add_comments=True)
     doc_data = []
-    filtered_files = [x for x in files if Path(x["name"]).suffix.lstrip(".") in allowed_extensions]
+
+    filtered_files = [x for x in files if Path(x["uri"]).suffix.lstrip(".") in allowed_extensions]
     for f in filtered_files:
         txt = f["file_bytes"]
         row = {

--- a/src/soliplex/agents/scm/base.py
+++ b/src/soliplex/agents/scm/base.py
@@ -322,6 +322,8 @@ class BaseSCMProvider(ABC):
 
         async with self.get_session() as session:
             async with session.get(url) as response:
+                if response.content_type != "application/json":  # pragma: no cover
+                    logger.error(f"Unexpected response type: {response.content_type} - response: {response.text}")
                 resp = await response.json()
 
                 await self.validate_response(response, resp)


### PR DESCRIPTION
## Summary
bug: change extension filtering to use uri instead of name to avoid missing file names
feat: add logging for invalid response from list-files


## Test Plan
- [x] Tests pass locally
- [x] Manual testing completed

