### PR TITLE
feat: add schedule hot loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ AUTH_TRUST_PROXY_HEADERS=false
 
 # Manifest scheduling (requires SCHEDULER_ENABLED=true)
 MANIFEST_DIR=/path/to/manifests
+# SCHEDULER_RECONCILE_CRON="*/1 * * * *"   # how often the dir is rescanned
 
 # haiku-rag loading (runs `haiku-ingester run-batch` after each manifest run)
 HAIKU_LOAD_ENABLED=false
@@ -680,9 +681,28 @@ si-agent serve
 
 The server loads all manifests from the directory at startup, validates that all manifest IDs are unique, and then:
 
-- **Manifests with a `schedule`** are registered as cron jobs.
-- **Manifests without a `schedule`** are run once at startup (a
+- **Manifests with a `schedule`** are registered and run when their cron
+  expression is due.
+- **Manifests without a `schedule`** are run once when first seen (a
   fire-and-forget task), then never again unless triggered via the API.
+
+**Hot-reloading schedules:**
+
+The manifest directory is rescanned on a fixed interval (every minute by
+default; configurable via `SCHEDULER_RECONCILE_CRON`), so changes take
+effect **without restarting the server**:
+
+- **Added files** are picked up on the next scan — new schedules register,
+  and new unscheduled manifests run once.
+- **Removed files** are unregistered and stop firing.
+- **Edited `schedule` blocks** are re-read; the manifest is rescheduled to
+  its new cron expression (the next fire is computed from the change time,
+  not backfilled). Adding a `schedule` to a previously unscheduled manifest
+  starts scheduling it; removing the `schedule` stops it.
+
+A manifest that is invalid or introduces a duplicate id mid-edit is skipped
+for that scan (logged) and retried on the next one, so a bad save never
+takes down the scheduler.
 
 **Execution behavior:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "soliplex.agents"
-version = "0.7.0"
+version = "0.7.1"
 description = "Agents for use with soliplex-ingester"
 authors = [{ name = "Enfold Systems", email = "info@enfoldsystems.net" }]
 readme = "README.md"
@@ -22,6 +22,7 @@ dependencies = [
     "aioboto3>=14.0.0",
     "aiofiles>=25.1.0",
     "aiohttp>=3.13.2",
+    "croniter>=2.0.0",
     "fastapi>=0.115.0",
     "fastapi-crons>=2.1.1",
     "jinja2>=3.1.6",

--- a/src/soliplex/agents/config.py
+++ b/src/soliplex/agents/config.py
@@ -101,6 +101,9 @@ class Settings(BaseSettings):
 
     # scheduler settings
     scheduler_enabled: bool = False  # turn on scheduler
+    # Cron expression for how often the manifest directory is rescanned to
+    # hot-reload schedule changes and added/removed manifest files.
+    scheduler_reconcile_cron: str = "*/1 * * * *"
 
     # State settings
     state_dir: str = "sync_state"

--- a/src/soliplex/agents/manifest/schedule_registry.py
+++ b/src/soliplex/agents/manifest/schedule_registry.py
@@ -1,0 +1,127 @@
+"""In-memory registry of manifest schedules for hot-reloading.
+
+The registry is reconciled against the manifest directory on a fixed
+interval so that added, removed, and re-scheduled manifests take effect
+without restarting the server.
+
+This module is deliberately pure: it performs no filesystem or scheduler
+I/O. It receives already-parsed manifests plus the current time and returns
+the actions the caller should take (which schedules were added, removed, or
+changed, and which manifests are due to run now). The server glue owns the
+directory scan and the actual execution.
+"""
+
+import logging
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+
+from croniter import croniter
+
+from soliplex.agents.config import Manifest
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ScheduleEntry:
+    """A single manifest's schedule state within the registry."""
+
+    manifest_id: str
+    path: str
+    cron_expr: str | None  # None for manifests without a schedule
+    next_run: datetime | None  # None when unscheduled or cron is invalid
+
+
+@dataclass
+class ReconcileResult:
+    """Actions the caller should take after a reconcile pass.
+
+    ``added``/``rescheduled`` carry entries (so the caller can log the cron
+    expression); ``removed`` carries ids. ``to_run`` lists the manifests
+    that should be executed this cycle: scheduled manifests that are due,
+    plus newly-seen unscheduled manifests (which run once).
+    """
+
+    added: list[ScheduleEntry] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    rescheduled: list[ScheduleEntry] = field(default_factory=list)
+    to_run: list[ScheduleEntry] = field(default_factory=list)
+
+
+def _next_run(cron_expr: str, now: datetime) -> datetime | None:
+    """Return the next fire time strictly after *now*, or None if invalid."""
+    if not croniter.is_valid(cron_expr):
+        logger.warning(
+            "Invalid cron expression %r; manifest will not be scheduled",
+            cron_expr,
+        )
+        return None
+    return croniter(cron_expr, now).get_next(datetime)
+
+
+class ScheduleRegistry:
+    """Tracks manifest schedules and diffs them against the filesystem."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ScheduleEntry] = {}
+
+    def reconcile(
+        self,
+        pairs: list[tuple[Manifest, str]],
+        now: datetime,
+    ) -> ReconcileResult:
+        """Diff the registry against *pairs* and return the actions to take.
+
+        Args:
+            pairs: ``(Manifest, path)`` tuples currently present on disk.
+            now: The current time (timezone-aware, UTC).
+
+        Returns:
+            A :class:`ReconcileResult` describing added/removed/rescheduled
+            manifests and those due to run now.
+        """
+        result = ReconcileResult()
+        seen: set[str] = set()
+
+        for manifest, path in pairs:
+            mid = manifest.id
+            seen.add(mid)
+            cron_expr = manifest.schedule.cron if manifest.schedule else None
+            existing = self._entries.get(mid)
+
+            if existing is None:
+                entry = ScheduleEntry(
+                    manifest_id=mid,
+                    path=path,
+                    cron_expr=cron_expr,
+                    next_run=(_next_run(cron_expr, now) if cron_expr is not None else None),
+                )
+                self._entries[mid] = entry
+                result.added.append(entry)
+                if cron_expr is None:
+                    # Unscheduled manifests run once when first seen.
+                    result.to_run.append(entry)
+                continue
+
+            # Existing manifest: keep the path current and detect a change
+            # to the schedule (added, removed, or a different cron).
+            existing.path = path
+            if cron_expr != existing.cron_expr:
+                existing.cron_expr = cron_expr
+                existing.next_run = _next_run(cron_expr, now) if cron_expr is not None else None
+                result.rescheduled.append(existing)
+
+        for mid in list(self._entries):
+            if mid not in seen:
+                del self._entries[mid]
+                result.removed.append(mid)
+
+        for entry in self._entries.values():
+            if entry.cron_expr is not None and entry.next_run is not None and now >= entry.next_run:
+                result.to_run.append(entry)
+                # Advance to the next future occurrence so a single fire
+                # happens even if several were missed (no catch-up storm).
+                entry.next_run = _next_run(entry.cron_expr, now)
+
+        return result

--- a/src/soliplex/agents/server/__init__.py
+++ b/src/soliplex/agents/server/__init__.py
@@ -6,6 +6,8 @@ Provides REST API endpoints for filesystem, SCM, and WebDAV ingestion agents.
 
 import asyncio
 import logging
+from datetime import UTC
+from datetime import datetime
 from pathlib import Path
 
 from fastapi import APIRouter
@@ -14,6 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from soliplex.agents.config import configure_logging
 from soliplex.agents.config import settings
+from soliplex.agents.manifest.schedule_registry import ScheduleRegistry
 
 from .haiku_queue import enqueue_load
 from .haiku_queue import start_worker
@@ -30,36 +33,62 @@ from .routes.webdav import webdav_router
 
 logger = logging.getLogger(__name__)
 
-
-async def _run_manifest_at_startup(manifest_path: str) -> None:
-    """Run a single manifest and log the outcome."""
-    from soliplex.agents.manifest import runner as manifest_runner
-
-    try:
-        m = manifest_runner.load_manifest(manifest_path)
-        async with get_global_manifest_semaphore():
-            lock = get_manifest_lock(m.id)
-            async with lock:
-                result = await manifest_runner.run_manifest(m)
-                count = len(result.get("results", []))
-                logger.info(
-                    "Startup manifest '%s' completed: %d components",
-                    m.id,
-                    count,
-                )
-        if settings.haiku_load_enabled:
-            await enqueue_load(m)
-    except Exception:
-        logger.exception("Error running startup manifest %s", manifest_path)
+# Registry of manifest schedules, reconciled against the manifest directory
+# on each tick so schedule edits and added/removed files hot-reload without
+# a restart.
+_schedule_registry = ScheduleRegistry()
 
 
-def setup_manifest_schedules(crons) -> None:
-    """Register cron jobs for scheduled manifests and fire-and-forget
-    tasks for unscheduled ones.
+async def run_scheduled_manifest(manifest_id: str, path: str) -> None:
+    """Execute one manifest, honoring the global one-at-a-time lock.
+
+    Skips (rather than queues) when another manifest is already running so
+    frequent schedules don't pile up. Failures are logged, not raised, since
+    this is invoked as a fire-and-forget task.
 
     Args:
-        crons: A ``fastapi_crons.Crons`` instance used to register
-            cron handlers.
+        manifest_id: The manifest's id (used for locking and logging).
+        path: Path to the manifest YAML file, reloaded fresh on each run.
+    """
+    from soliplex.agents.manifest import runner as manifest_runner
+
+    if is_manifest_running(manifest_id):
+        logger.warning(
+            "Skipping manifest '%s': previous run still in progress",
+            manifest_id,
+        )
+        return
+    if is_any_manifest_running():
+        logger.info(
+            "Skipping manifest '%s': another manifest is running",
+            manifest_id,
+        )
+        return
+
+    try:
+        async with get_global_manifest_semaphore():
+            lock = get_manifest_lock(manifest_id)
+            async with lock:
+                loaded = manifest_runner.load_manifest(path)
+                result = await manifest_runner.run_manifest(loaded)
+                logger.info(
+                    "Manifest '%s' completed: %d components",
+                    manifest_id,
+                    len(result.get("results", [])),
+                )
+        if settings.haiku_load_enabled:
+            await enqueue_load(loaded)
+    except Exception:
+        logger.exception("Error running manifest '%s'", manifest_id)
+
+
+async def reconcile_manifest_schedules() -> None:
+    """Rescan the manifest directory and fire due/newly-added manifests.
+
+    Runs on a fixed interval (see ``scheduler_reconcile_cron``) so that
+    added, removed, and re-scheduled manifest files take effect without a
+    restart. Scheduled manifests fire when due; manifests without a schedule
+    run once when first seen.
     """
     from soliplex.agents.manifest import runner as manifest_runner
 
@@ -77,59 +106,38 @@ def setup_manifest_schedules(crons) -> None:
     try:
         pairs = manifest_runner.load_manifests_with_paths(settings.manifest_dir)
     except ValueError:
-        logger.exception("Error loading manifests from directory")
+        # e.g. a transient duplicate id mid-edit -- keep the last good state.
+        logger.exception("Error loading manifests; skipping this reconcile")
         return
 
-    for m_obj, yml_path in pairs:
-        if m_obj.schedule:
+    result = _schedule_registry.reconcile(pairs, datetime.now(UTC))
 
-            def make_handler(mpath, mid):
-                async def handler():
-                    if is_manifest_running(mid):
-                        logger.warning(
-                            "Skipping manifest '%s': previous run still in progress",
-                            mid,
-                        )
-                        return
-                    if is_any_manifest_running():
-                        logger.info(
-                            "Skipping manifest '%s': another manifest is running",
-                            mid,
-                        )
-                        return
-                    async with get_global_manifest_semaphore():
-                        lock = get_manifest_lock(mid)
-                        async with lock:
-                            loaded = manifest_runner.load_manifest(mpath)
-                            result = await manifest_runner.run_manifest(loaded)
-                            logger.info(
-                                "Manifest %s completed: %d components",
-                                mpath,
-                                len(result.get("results", [])),
-                            )
-                    if settings.haiku_load_enabled:
-                        await enqueue_load(loaded)
-
-                return handler
-
-            crons.cron(
-                m_obj.schedule.cron,
-                name=f"manifest_{m_obj.id}",
-            )(make_handler(yml_path, m_obj.id))
+    for entry in result.added:
+        if entry.cron_expr is not None:
             logger.info(
                 "Scheduled manifest '%s' cron='%s'",
-                m_obj.id,
-                m_obj.schedule.cron,
+                entry.manifest_id,
+                entry.cron_expr,
             )
         else:
-            asyncio.create_task(
-                _run_manifest_at_startup(yml_path),
-                name=f"startup_manifest_{m_obj.id}",
-            )
             logger.info(
-                "Queued startup run for manifest '%s'",
-                m_obj.id,
+                "Registered manifest '%s' (no schedule; one-time run)",
+                entry.manifest_id,
             )
+    for entry in result.rescheduled:
+        logger.info(
+            "Rescheduled manifest '%s' cron='%s'",
+            entry.manifest_id,
+            entry.cron_expr,
+        )
+    for mid in result.removed:
+        logger.info("Unregistered manifest '%s' (file removed)", mid)
+
+    for entry in result.to_run:
+        asyncio.create_task(
+            run_scheduled_manifest(entry.manifest_id, entry.path),
+            name=f"manifest_run_{entry.manifest_id}",
+        )
 
 
 def configure_logfire(app: FastAPI) -> None:
@@ -178,7 +186,10 @@ async def lifespan(app: FastAPI):
         start_worker()
 
     if settings.scheduler_enabled:
-        setup_manifest_schedules(_crons)
+        # Run one reconcile immediately so schedules register and
+        # unscheduled manifests run at startup; the reconciler cron picks
+        # up changes on every subsequent tick.
+        await reconcile_manifest_schedules()
 
     yield
     if settings.haiku_load_enabled:
@@ -231,6 +242,10 @@ if settings.scheduler_enabled:
     state_backend = SQLiteStateBackend(db_path=":memory:")
     _crons = Crons(app, state_backend=state_backend)
     app.include_router(get_cron_router())
+
+    @_crons.cron(settings.scheduler_reconcile_cron, name="manifest_reconciler")
+    async def _manifest_reconciler_job():
+        await reconcile_manifest_schedules()
 
 
 # Include the parent router in the app

--- a/tests/unit/test_schedule_registry.py
+++ b/tests/unit/test_schedule_registry.py
@@ -1,0 +1,151 @@
+"""Tests for the manifest ScheduleRegistry."""
+
+import logging
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+
+from soliplex.agents.config import Manifest
+from soliplex.agents.manifest.schedule_registry import ScheduleRegistry
+
+_LOGGER = "soliplex.agents.manifest.schedule_registry"
+
+
+def _manifest(mid: str, cron: str | None = None) -> Manifest:
+    data: dict = {
+        "id": mid,
+        "name": f"Manifest {mid}",
+        "source": f"src-{mid}",
+        "components": [{"type": "fs", "name": "comp", "path": "/data"}],
+    }
+    if cron is not None:
+        data["schedule"] = {"cron": cron}
+    return Manifest(**data)
+
+
+def _pairs(*specs: tuple[str, str | None]) -> list[tuple[Manifest, str]]:
+    return [(_manifest(mid, cron), f"/manifests/{mid}.yml") for mid, cron in specs]
+
+
+def test_new_scheduled_registers_but_not_due():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, 0, 0, 30, tzinfo=UTC)
+
+    res = reg.reconcile(_pairs(("a", "*/5 * * * *")), now)
+
+    assert [e.manifest_id for e in res.added] == ["a"]
+    assert res.to_run == []
+    entry = reg._entries["a"]
+    assert entry.cron_expr == "*/5 * * * *"
+    assert entry.next_run == datetime(2026, 1, 1, 0, 5, tzinfo=UTC)
+
+
+def test_new_unscheduled_runs_once():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+
+    res = reg.reconcile(_pairs(("u", None)), now)
+    assert [e.manifest_id for e in res.added] == ["u"]
+    assert [e.manifest_id for e in res.to_run] == ["u"]
+    assert reg._entries["u"].next_run is None
+
+    # A second reconcile must not run it again.
+    res2 = reg.reconcile(_pairs(("u", None)), now + timedelta(minutes=1))
+    assert res2.added == []
+    assert res2.to_run == []
+    assert res2.rescheduled == []
+
+
+def test_invalid_cron_is_not_scheduled(caplog):
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        res = reg.reconcile(_pairs(("bad", "not a cron")), now)
+
+    assert [e.manifest_id for e in res.added] == ["bad"]
+    assert res.to_run == []
+    assert reg._entries["bad"].next_run is None
+    assert "Invalid cron expression" in caplog.text
+
+
+def test_removed_manifest_dropped():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    reg.reconcile(_pairs(("a", "0 0 * * *"), ("b", None)), now)
+
+    res = reg.reconcile(_pairs(("a", "0 0 * * *")), now + timedelta(minutes=1))
+
+    assert res.removed == ["b"]
+    assert "b" not in reg._entries
+
+
+def test_cron_change_reschedules():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, 0, 0, 30, tzinfo=UTC)
+    reg.reconcile(_pairs(("a", "0 0 * * *")), now)
+
+    res = reg.reconcile(_pairs(("a", "*/5 * * * *")), now)
+
+    assert [e.manifest_id for e in res.rescheduled] == ["a"]
+    assert reg._entries["a"].cron_expr == "*/5 * * * *"
+    assert reg._entries["a"].next_run == datetime(2026, 1, 1, 0, 5, tzinfo=UTC)
+
+
+def test_schedule_added_to_unscheduled():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, 0, 0, 30, tzinfo=UTC)
+    reg.reconcile(_pairs(("a", None)), now)
+
+    res = reg.reconcile(_pairs(("a", "*/5 * * * *")), now)
+
+    assert [e.manifest_id for e in res.rescheduled] == ["a"]
+    assert reg._entries["a"].next_run == datetime(2026, 1, 1, 0, 5, tzinfo=UTC)
+    assert res.to_run == []  # no longer a one-time unscheduled run
+
+
+def test_schedule_removed_from_scheduled():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    reg.reconcile(_pairs(("a", "0 0 * * *")), now)
+
+    res = reg.reconcile(_pairs(("a", None)), now)
+
+    assert [e.manifest_id for e in res.rescheduled] == ["a"]
+    assert reg._entries["a"].cron_expr is None
+    assert reg._entries["a"].next_run is None
+    assert res.to_run == []  # removing a schedule does not trigger a run
+
+
+def test_due_manifest_fires_and_advances():
+    reg = ScheduleRegistry()
+    now1 = datetime(2026, 1, 1, 0, 0, 30, tzinfo=UTC)
+    reg.reconcile(_pairs(("a", "*/5 * * * *")), now1)  # next_run 00:05
+
+    now2 = datetime(2026, 1, 1, 0, 5, 10, tzinfo=UTC)
+    res = reg.reconcile(_pairs(("a", "*/5 * * * *")), now2)
+
+    assert [e.manifest_id for e in res.to_run] == ["a"]
+    # Advanced to the next future occurrence (no catch-up storm).
+    assert reg._entries["a"].next_run == datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+
+
+def test_scheduled_not_due_does_not_run():
+    reg = ScheduleRegistry()
+    now1 = datetime(2026, 1, 1, 0, 0, 30, tzinfo=UTC)
+    reg.reconcile(_pairs(("a", "*/5 * * * *")), now1)  # next_run 00:05
+
+    now2 = datetime(2026, 1, 1, 0, 2, tzinfo=UTC)  # before 00:05
+    res = reg.reconcile(_pairs(("a", "*/5 * * * *")), now2)
+
+    assert res.to_run == []
+
+
+def test_existing_path_is_updated():
+    reg = ScheduleRegistry()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    reg.reconcile([(_manifest("a", None), "/old/a.yml")], now)
+
+    reg.reconcile([(_manifest("a", None), "/new/a.yml")], now)
+
+    assert reg._entries["a"].path == "/new/a.yml"

--- a/tests/unit/test_server_scheduling.py
+++ b/tests/unit/test_server_scheduling.py
@@ -1,4 +1,4 @@
-"""Tests for manifest scheduling in server startup."""
+"""Tests for manifest scheduling and hot-reload reconciliation."""
 
 import asyncio
 import logging
@@ -8,19 +8,24 @@ from unittest.mock import patch
 
 import pytest
 
-from soliplex.agents.server import _run_manifest_at_startup
-from soliplex.agents.server import setup_manifest_schedules
+import soliplex.agents.server as server
+from soliplex.agents.manifest.schedule_registry import ScheduleRegistry
+from soliplex.agents.server import reconcile_manifest_schedules
+from soliplex.agents.server import run_scheduled_manifest
+from soliplex.agents.server.locks import get_global_manifest_semaphore
 from soliplex.agents.server.locks import get_manifest_lock
 from soliplex.agents.server.locks import is_manifest_running
 from soliplex.agents.server.locks import reset_locks
 
 
 @pytest.fixture(autouse=True)
-def _clean_locks():
-    """Reset the lock registry between tests."""
+def _clean_state():
+    """Reset locks and the schedule registry between tests."""
     reset_locks()
+    server._schedule_registry = ScheduleRegistry()
     yield
     reset_locks()
+    server._schedule_registry = ScheduleRegistry()
 
 
 def _write_manifest(tmp_path, name, mid, schedule=None):
@@ -40,200 +45,12 @@ def _write_manifest(tmp_path, name, mid, schedule=None):
     (tmp_path / name).write_text("\n".join(lines) + "\n")
 
 
-class TestRunManifestAtStartup:
+class TestRunScheduledManifest:
     @pytest.mark.asyncio
-    async def test_runs_manifest_and_logs(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "m.yml", "startup-m")
+    async def test_runs_and_logs(self, tmp_path, caplog):
+        _write_manifest(tmp_path, "m.yml", "run-m")
         with (
-            patch(
-                "soliplex.agents.manifest.runner.run_manifest",
-                new_callable=AsyncMock,
-                return_value={
-                    "results": [{"component": "comp"}],
-                },
-            ),
-            caplog.at_level(logging.INFO),
-        ):
-            await _run_manifest_at_startup(str(tmp_path / "m.yml"))
-        assert "Startup manifest 'startup-m' completed" in caplog.text
-        assert "1 components" in caplog.text
-
-    @pytest.mark.asyncio
-    async def test_logs_error_on_failure(self, caplog):
-        with caplog.at_level(logging.ERROR):
-            await _run_manifest_at_startup("/nonexistent.yml")
-        assert "Error running startup manifest" in caplog.text
-
-    @pytest.mark.asyncio
-    async def test_acquires_manifest_lock(self, tmp_path):
-        """Startup task holds the manifest lock while running."""
-        _write_manifest(tmp_path, "m.yml", "lock-test")
-        lock_was_held = False
-
-        async def fake_run(manifest):
-            nonlocal lock_was_held
-            lock_was_held = is_manifest_running("lock-test")
-            return {"results": []}
-
-        with patch(
-            "soliplex.agents.manifest.runner.run_manifest",
-            side_effect=fake_run,
-        ):
-            await _run_manifest_at_startup(str(tmp_path / "m.yml"))
-
-        assert lock_was_held
-
-
-class TestSetupManifestSchedules:
-    def test_no_manifest_dir_returns_early(self):
-        crons = MagicMock()
-        with patch("soliplex.agents.server.settings") as mock_settings:
-            mock_settings.manifest_dir = None
-            setup_manifest_schedules(crons)
-        crons.cron.assert_not_called()
-
-    def test_non_directory_warns(self, tmp_path, caplog):
-        crons = MagicMock()
-        fake_file = tmp_path / "not_a_dir.txt"
-        fake_file.write_text("hi")
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
-            caplog.at_level(logging.WARNING),
-        ):
-            mock_settings.manifest_dir = str(fake_file)
-            setup_manifest_schedules(crons)
-        assert "not a directory" in caplog.text
-        crons.cron.assert_not_called()
-
-    def test_duplicate_ids_logs_error(self, tmp_path, caplog):
-        for name in ["a.yml", "b.yml"]:
-            _write_manifest(tmp_path, name, "same-id", schedule="0 0 * * *")
-        crons = MagicMock()
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
-            caplog.at_level(logging.ERROR, logger="soliplex.agents.server"),
-        ):
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-        assert "Error loading manifests" in caplog.text
-        crons.cron.assert_not_called()
-
-    def test_scheduled_manifest_registers_cron(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "cron.yml", "cron-m", schedule="0 0 * * *")
-        crons = MagicMock()
-        decorator = MagicMock(side_effect=lambda fn: fn)
-        crons.cron.return_value = decorator
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
-            caplog.at_level(logging.INFO),
-        ):
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-        crons.cron.assert_called_once_with("0 0 * * *", name="manifest_cron-m")
-        assert "Scheduled manifest 'cron-m'" in caplog.text
-
-    def test_unscheduled_manifest_creates_startup_task(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "no-sched.yml", "nosched-m")
-        crons = MagicMock()
-
-        mock_task = MagicMock()
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
-            # Force a plain MagicMock: patch() auto-uses AsyncMock for an async
-            # function, which would still create an un-awaited coroutine when
-            # called and handed to the mocked create_task.
-            patch("soliplex.agents.server._run_manifest_at_startup", new=MagicMock()),
-            patch(
-                "soliplex.agents.server.asyncio.create_task",
-                return_value=mock_task,
-            ) as mock_create,
-            caplog.at_level(logging.INFO),
-        ):
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-        mock_create.assert_called_once()
-        assert mock_create.call_args.kwargs["name"] == ("startup_manifest_nosched-m")
-        crons.cron.assert_not_called()
-        assert "Queued startup run for manifest 'nosched-m'" in (caplog.text)
-
-    def test_mixed_scheduled_and_unscheduled(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "a.yml", "sched-a", schedule="*/5 * * * *")
-        _write_manifest(tmp_path, "b.yml", "nosched-b")
-        crons = MagicMock()
-        decorator = MagicMock(side_effect=lambda fn: fn)
-        crons.cron.return_value = decorator
-
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
-            patch("soliplex.agents.server._run_manifest_at_startup", new=MagicMock()),
-            patch(
-                "soliplex.agents.server.asyncio.create_task",
-            ) as mock_create,
-            caplog.at_level(logging.INFO),
-        ):
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-        crons.cron.assert_called_once_with("*/5 * * * *", name="manifest_sched-a")
-        mock_create.assert_called_once()
-
-    def test_empty_directory(self, tmp_path):
-        crons = MagicMock()
-        with patch("soliplex.agents.server.settings") as mock_settings:
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-        crons.cron.assert_not_called()
-
-
-class TestCronHandlerSkipsWhenBusy:
-    """Cron handler must skip execution when the manifest is already running."""
-
-    @pytest.mark.asyncio
-    async def test_cron_handler_skips_if_locked(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "a.yml", "busy-cron", schedule="* * * * *")
-        crons = MagicMock()
-        registered_handler = None
-
-        def capture_handler(fn):
-            nonlocal registered_handler
-            registered_handler = fn
-            return fn
-
-        crons.cron.return_value = capture_handler
-
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
-            caplog.at_level(logging.WARNING),
-        ):
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-
-        assert registered_handler is not None
-
-        # Simulate the manifest already running by holding its lock
-        lock = get_manifest_lock("busy-cron")
-        await lock.acquire()
-        try:
-            await registered_handler()
-        finally:
-            lock.release()
-
-        assert "previous run still in progress" in caplog.text
-
-    @pytest.mark.asyncio
-    async def test_cron_handler_runs_when_free(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "a.yml", "free-cron", schedule="* * * * *")
-        crons = MagicMock()
-        registered_handler = None
-
-        def capture_handler(fn):
-            nonlocal registered_handler
-            registered_handler = fn
-            return fn
-
-        crons.cron.return_value = capture_handler
-
-        with (
-            patch("soliplex.agents.server.settings") as mock_settings,
+            patch("soliplex.agents.server.settings") as ms,
             patch(
                 "soliplex.agents.manifest.runner.run_manifest",
                 new_callable=AsyncMock,
@@ -241,25 +58,183 @@ class TestCronHandlerSkipsWhenBusy:
             ),
             caplog.at_level(logging.INFO),
         ):
-            mock_settings.manifest_dir = str(tmp_path)
-            setup_manifest_schedules(crons)
-            await registered_handler()
+            ms.haiku_load_enabled = False
+            await run_scheduled_manifest("run-m", str(tmp_path / "m.yml"))
+        assert "Manifest 'run-m' completed: 1 components" in caplog.text
 
-        assert "completed" in caplog.text
-        assert "previous run still in progress" not in caplog.text
+    @pytest.mark.asyncio
+    async def test_skips_when_same_manifest_running(self, caplog):
+        lock = get_manifest_lock("busy")
+        await lock.acquire()
+        try:
+            with caplog.at_level(logging.WARNING):
+                await run_scheduled_manifest("busy", "/does-not-matter.yml")
+        finally:
+            lock.release()
+        assert "previous run still in progress" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_skips_when_another_manifest_running(self, caplog):
+        sem = get_global_manifest_semaphore()
+        await sem.acquire()
+        try:
+            with caplog.at_level(logging.INFO):
+                await run_scheduled_manifest("x", "/does-not-matter.yml")
+        finally:
+            sem.release()
+        assert "another manifest is running" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_error_on_failure(self, tmp_path, caplog):
+        _write_manifest(tmp_path, "m.yml", "err-m")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch(
+                "soliplex.agents.manifest.runner.run_manifest",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(logging.ERROR),
+        ):
+            ms.haiku_load_enabled = False
+            await run_scheduled_manifest("err-m", str(tmp_path / "m.yml"))
+        assert "Error running manifest 'err-m'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_acquires_manifest_lock(self, tmp_path):
+        _write_manifest(tmp_path, "m.yml", "lock-m")
+        held = False
+
+        async def fake_run(manifest):
+            nonlocal held
+            held = is_manifest_running("lock-m")
+            return {"results": []}
+
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch(
+                "soliplex.agents.manifest.runner.run_manifest",
+                side_effect=fake_run,
+            ),
+        ):
+            ms.haiku_load_enabled = False
+            await run_scheduled_manifest("lock-m", str(tmp_path / "m.yml"))
+        assert held
+
+
+class TestReconcileManifestSchedules:
+    @pytest.mark.asyncio
+    async def test_no_manifest_dir_returns_early(self):
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.asyncio.create_task") as mock_create,
+        ):
+            ms.manifest_dir = None
+            await reconcile_manifest_schedules()
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_directory_warns(self, tmp_path, caplog):
+        fake_file = tmp_path / "not_a_dir.txt"
+        fake_file.write_text("hi")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.asyncio.create_task") as mock_create,
+            caplog.at_level(logging.WARNING),
+        ):
+            ms.manifest_dir = str(fake_file)
+            await reconcile_manifest_schedules()
+        assert "not a directory" in caplog.text
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ids_logs_error_and_skips(self, tmp_path, caplog):
+        _write_manifest(tmp_path, "a.yml", "dup", schedule="0 0 * * *")
+        _write_manifest(tmp_path, "b.yml", "dup", schedule="0 0 * * *")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.asyncio.create_task") as mock_create,
+            caplog.at_level(logging.ERROR, logger="soliplex.agents.server"),
+        ):
+            ms.manifest_dir = str(tmp_path)
+            await reconcile_manifest_schedules()
+        assert "Error loading manifests" in caplog.text
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_registers_scheduled_and_runs_unscheduled(self, tmp_path, caplog):
+        _write_manifest(tmp_path, "sched.yml", "sched-a", schedule="*/5 * * * *")
+        _write_manifest(tmp_path, "un.yml", "unsched-b")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.run_scheduled_manifest", new=MagicMock()),
+            patch("soliplex.agents.server.asyncio.create_task") as mock_create,
+            caplog.at_level(logging.INFO),
+        ):
+            ms.manifest_dir = str(tmp_path)
+            await reconcile_manifest_schedules()
+        names = [c.kwargs["name"] for c in mock_create.call_args_list]
+        # Scheduled manifest registered but not fired; unscheduled runs once.
+        assert names == ["manifest_run_unsched-b"]
+        assert "Scheduled manifest 'sched-a' cron='*/5 * * * *'" in caplog.text
+        assert "Registered manifest 'unsched-b'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_new_file_picked_up_across_reconciles(self, tmp_path):
+        _write_manifest(tmp_path, "a.yml", "a", schedule="*/5 * * * *")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.run_scheduled_manifest", new=MagicMock()),
+            patch("soliplex.agents.server.asyncio.create_task") as mock_create,
+        ):
+            ms.manifest_dir = str(tmp_path)
+            await reconcile_manifest_schedules()
+            mock_create.reset_mock()
+            _write_manifest(tmp_path, "b.yml", "b")  # new unscheduled file
+            await reconcile_manifest_schedules()
+            names = [c.kwargs["name"] for c in mock_create.call_args_list]
+        assert names == ["manifest_run_b"]
+
+    @pytest.mark.asyncio
+    async def test_removed_file_unregistered(self, tmp_path, caplog):
+        _write_manifest(tmp_path, "a.yml", "a", schedule="*/5 * * * *")
+        _write_manifest(tmp_path, "b.yml", "b", schedule="*/5 * * * *")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.run_scheduled_manifest", new=MagicMock()),
+            patch("soliplex.agents.server.asyncio.create_task"),
+            caplog.at_level(logging.INFO),
+        ):
+            ms.manifest_dir = str(tmp_path)
+            await reconcile_manifest_schedules()
+            (tmp_path / "b.yml").unlink()
+            caplog.clear()
+            await reconcile_manifest_schedules()
+        assert "Unregistered manifest 'b'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_rescheduled_logged(self, tmp_path, caplog):
+        _write_manifest(tmp_path, "a.yml", "a", schedule="0 0 * * *")
+        with (
+            patch("soliplex.agents.server.settings") as ms,
+            patch("soliplex.agents.server.run_scheduled_manifest", new=MagicMock()),
+            patch("soliplex.agents.server.asyncio.create_task"),
+            caplog.at_level(logging.INFO),
+        ):
+            ms.manifest_dir = str(tmp_path)
+            await reconcile_manifest_schedules()
+            _write_manifest(tmp_path, "a.yml", "a", schedule="*/5 * * * *")
+            caplog.clear()
+            await reconcile_manifest_schedules()
+        assert "Rescheduled manifest 'a' cron='*/5 * * * *'" in caplog.text
 
 
 class TestGlobalManifestLock:
-    """A cron fire must skip (not queue) while any manifest is running."""
+    """A run must skip (not queue) while another manifest is running."""
 
     @pytest.mark.asyncio
     async def test_second_manifest_skips_while_first_runs(self, tmp_path, caplog):
-        _write_manifest(tmp_path, "a.yml", "glob-a", schedule="* * * * *")
-        _write_manifest(tmp_path, "b.yml", "glob-b", schedule="* * * * *")
-        crons = MagicMock()
-        handlers = []
-        crons.cron.return_value = lambda fn: (handlers.append(fn), fn)[1]
-
+        _write_manifest(tmp_path, "a.yml", "glob-a")
+        _write_manifest(tmp_path, "b.yml", "glob-b")
         started = []
         release = asyncio.Event()
 
@@ -269,22 +244,19 @@ class TestGlobalManifestLock:
             return {"results": []}
 
         with (
-            patch("soliplex.agents.server.settings") as mock_settings,
+            patch("soliplex.agents.server.settings") as ms,
             patch(
                 "soliplex.agents.manifest.runner.run_manifest",
                 side_effect=fake_run,
             ),
             caplog.at_level(logging.INFO),
         ):
-            mock_settings.manifest_dir = str(tmp_path)
-            mock_settings.haiku_load_enabled = False
-            setup_manifest_schedules(crons)
-            first = asyncio.create_task(handlers[0]())
-            # Let the first handler acquire the global lock and start running.
+            ms.haiku_load_enabled = False
+            first = asyncio.create_task(run_scheduled_manifest("glob-a", str(tmp_path / "a.yml")))
+            # Let the first run acquire the global lock and start running.
             await asyncio.sleep(0)
-            # Second fire while the first is still running must be dropped,
-            # not queued behind it.
-            await handlers[1]()
+            # Second run while the first is in progress must be dropped.
+            await run_scheduled_manifest("glob-b", str(tmp_path / "b.yml"))
             release.set()
             await first
 

--- a/uv.lock
+++ b/uv.lock
@@ -342,15 +342,6 @@ wheels = [
 ]
 
 [[package]]
-name = "batched"
-version = "0.1.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/40/8d9a8ed9b95cb95acf599698557b7074b462df652823a61e7e43899aa519/batched-0.1.5.tar.gz", hash = "sha256:58b8a41d3f8d4d39a0edba79c6238ed204938cfc2c8908224919d70af07c610d", size = 23940, upload-time = "2025-07-14T09:58:31.862Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/c8/16a977fd90cdc974ef7781e237b8a0e0008a6204768ededbef2b2ff1bb43/batched-0.1.5-py3-none-any.whl", hash = "sha256:356dae99f15c906629992e4bd3481a857114790b5316268fa38fe8ad0d0b9480", size = 29367, upload-time = "2025-07-14T09:58:30.968Z" },
-]
-
-[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
@@ -437,104 +428,123 @@ wheels = [
 
 [[package]]
 name = "cffi"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
-    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
-    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
-    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
-    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.7"
+version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
-    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
-    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
-    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
-    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
-    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
-    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
-    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
-    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
-    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
-    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -1203,11 +1213,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.5"
+version = "3.29.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c8/35bdf04fb30755e2ed758f877edf3eb4a243c2463d3a258cc28b18b7a6e2/filelock-3.29.6.tar.gz", hash = "sha256:895c532ef3f4ef04972b9446a8c4e2931a5c399ff3c4be4c9369f2639b80f793", size = 70301, upload-time = "2026-07-06T23:08:08.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/49/7467c2946ccd9617f7da38187071bdc45bb9a95df51f4d63d6622432ce4e/filelock-3.29.6-py3-none-any.whl", hash = "sha256:14d5f5597d2e0c4dbd774cfb6d8132da1db44da83732aab679d54f7dcf97ab65", size = 45478, upload-time = "2026-07-06T23:08:07.197Z" },
 ]
 
 [[package]]
@@ -1412,14 +1422,14 @@ wheels = [
 
 [[package]]
 name = "haiku-rag"
-version = "0.65.1"
+version = "0.66.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "haiku-rag-slim", extra = ["cohere", "cross-encoder", "docling", "mxbai", "tui", "voyageai", "zeroentropy"] },
+    { name = "haiku-rag-slim", extra = ["cohere", "cross-encoder", "docling", "tui", "voyageai", "zeroentropy"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/1e/868089b005d5c208e507606ea7677d29a97ce8209924b62453bc9da62ebe/haiku_rag-0.65.1.tar.gz", hash = "sha256:4e7b0dca7838a01ac188f22b08d71f0a648e8cbc473145805013c403495e550f", size = 470446, upload-time = "2026-07-10T12:18:44.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ac/04bd4989759aca06d424ffcd0ab1170d6bfbbf1ae5b24291f46d360b4a02/haiku_rag-0.66.0.tar.gz", hash = "sha256:b018d86a10a53b9d94e352bcff943f1a0c2c2fb0a42f928c8870cb84fd877f8f", size = 470192, upload-time = "2026-07-14T13:07:55.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/e7/35b677eccdc054d8ba36524b2e2ba5cb41cb7cc2a12b3e6769cff6eee8f3/haiku_rag-0.65.1-py3-none-any.whl", hash = "sha256:5a7c34775ab8c171cd439716ca66df49f4ffa5ba75b2cd438fbedcf206c829d2", size = 7911, upload-time = "2026-07-10T12:18:43.259Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ad/73c28ca2d91e6c88358f9dea207686cdac092ecf388f475c134a249a59d9/haiku_rag-0.66.0-py3-none-any.whl", hash = "sha256:ce3f08d5aa1b682fe1f7921747d7cd5c78f15ffcabc9c188389bdcdcbbe69d48", size = 7917, upload-time = "2026-07-14T13:07:54.114Z" },
 ]
 
 [package.optional-dependencies]
@@ -1429,7 +1439,7 @@ ingester = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.65.1"
+version = "0.66.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1452,9 +1462,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/69/b62507bca4c5eeec0589b134c874810b1509cd3c9cf52939eb59c191eb8b/haiku_rag_slim-0.65.1.tar.gz", hash = "sha256:f1fb858c563eeb4d001b12b606f20b9d705ca6306df368eb5137ed857d7e9d12", size = 232288, upload-time = "2026-07-10T12:18:20.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/65/b25bff3ec7194482ae0a7eed7d67bdf98fb2c0d99c5266951c86b3df856f/haiku_rag_slim-0.66.0.tar.gz", hash = "sha256:1a56edc60030fb765f5711d93dd208e3491e8cb4ba03c1178482f77391f29c3e", size = 232342, upload-time = "2026-07-14T13:07:34.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/db/18e3780c29b99e0fb5ed05562f002c74c5bfdd826a368b2f59133e1f8e22/haiku_rag_slim-0.65.1-py3-none-any.whl", hash = "sha256:1772ccdfdca7c2eca5453e522cf1f18b44ba57ac087fd6b323a2d27e601b6e53", size = 311316, upload-time = "2026-07-10T12:18:19.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/04/e005e61bc58825b6cd520666a1fd2b2283bac21bacf101eb1014bcccd608/haiku_rag_slim-0.66.0-py3-none-any.whl", hash = "sha256:c83c44ec4e2a2f8a47df5ba79438285a8e04ee5c4b163a6ad9aff5e8d985ac0b", size = 310897, upload-time = "2026-07-14T13:07:33.243Z" },
 ]
 
 [package.optional-dependencies]
@@ -1475,10 +1485,6 @@ ingester = [
     { name = "obstore" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
-]
-mxbai = [
-    { name = "mxbai-rerank" },
-    { name = "transformers" },
 ]
 tui = [
     { name = "textual" },
@@ -1637,21 +1643,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.2"
+version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/ea/dc54b4dda5841cb3a7812a178695be776e7c15c597887c2ed892f17d015a/huggingface_hub-1.22.0.tar.gz", hash = "sha256:e2dfe5fe1ec3b87ba2709aa34555b23e3f3f6ad4d7255238e13ddb8348e6bbfa", size = 914232, upload-time = "2026-07-03T09:46:44.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9c/a1a377265abd8b823a2c661c665028ccb6b9fba1ca9d08e52ff679c20ecd/huggingface_hub-1.22.0-py3-none-any.whl", hash = "sha256:b09e19309ae09ee0a71892701c4fe70af39ab4e00817321dc62f2289a977249b", size = 765085, upload-time = "2026-07-03T09:46:42.832Z" },
 ]
 
 [[package]]
@@ -2002,7 +2009,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.7"
+version = "0.9.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2020,9 +2027,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/8b/a56b97a3b8a94f850fe2ec42351d4c508cc6bd7ca96644906c311e32ec5b/langsmith-0.9.7.tar.gz", hash = "sha256:40f8a66a466a7abd991a9df1b50de0a9d30c48ee0d3da46ce00516b68e41c9d7", size = 4711142, upload-time = "2026-07-02T20:11:09.619Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/68/8d8471233ee0cd82c2af946d76f80a01aeb8bb04160c392c1229fddf5d3d/langsmith-0.9.8.tar.gz", hash = "sha256:8c3d6a6d5246a3ea6d439b726d59edefba31dfb251de9eedb256119bbea4439e", size = 4710812, upload-time = "2026-07-06T19:06:10.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/95/0abb8647123c9ebbb31162bcdba3183f5f3d3bb2f752ef3d777ab715e88c/langsmith-0.9.7-py3-none-any.whl", hash = "sha256:a5ff9179b77eb0c3a0129294d30924eab13e51e2720f374372dbbc014c892911", size = 671052, upload-time = "2026-07-02T20:11:07.702Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/67/a85caaa99117bbc988a0df7faa39e7f68344361854638d86bcce0ffe3619/langsmith-0.9.8-py3-none-any.whl", hash = "sha256:098da9fc6c184284f17913cb813a41e28c5ab1508e90bd50db40c28166681017", size = 671148, upload-time = "2026-07-06T19:06:08.911Z" },
 ]
 
 [[package]]
@@ -2409,23 +2416,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
     { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
     { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
-]
-
-[[package]]
-name = "mxbai-rerank"
-version = "0.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "accelerate" },
-    { name = "batched" },
-    { name = "numpy" },
-    { name = "torch" },
-    { name = "tqdm" },
-    { name = "transformers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/76/a19c864a1025222d3304a888ed4ed9217bfdf55dbaf4ed37500ee03935e0/mxbai_rerank-0.1.6.tar.gz", hash = "sha256:8d08e8464796429a7415314ce6de682bf9b538eb4ee5a7ddcd1a07839ee02879", size = 21449, upload-time = "2025-06-02T14:59:42.45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/2a/503622b3a80272c662dabef421c9635168e5cbf6d51f0aa1883998561292/mxbai_rerank-0.1.6-py3-none-any.whl", hash = "sha256:aee94e7a14d5fba6520052ff2098f0f03db6cd9cc39553b7d2e82389deec9e05", size = 18458, upload-time = "2025-06-02T14:59:41.003Z" },
 ]
 
 [[package]]
@@ -4345,12 +4335,13 @@ wheels = [
 
 [[package]]
 name = "soliplex-agents"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "croniter" },
     { name = "fastapi" },
     { name = "fastapi-crons" },
     { name = "haiku-rag", extra = ["ingester"] },
@@ -4383,6 +4374,7 @@ requires-dist = [
     { name = "aioboto3", specifier = ">=14.0.0" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiohttp", specifier = ">=3.13.2" },
+    { name = "croniter", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastapi-crons", specifier = ">=2.1.1" },
     { name = "haiku-rag", extras = ["ingester"], specifier = ">=0.55.1" },
@@ -4691,35 +4683,34 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.68.3"
+version = "4.68.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
 ]
 
 [[package]]
 name = "transformers"
-version = "4.57.6"
+version = "5.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e6/4134ea2fbea322cddc7ffc94a0d8ee47fe32ce8e876b320cd37d88edfc4d/transformers-5.8.1.tar.gz", hash = "sha256:4dd5b6de4105725104d84fd6abd74b305f4debfc251b38c648ee5dd087cf543b", size = 8532019, upload-time = "2026-05-13T03:21:57.234Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b1/8be7e7ef0b5200491312201918b6125ef9c9df9dd0f0240ccef9ac824e6b/transformers-5.8.1-py3-none-any.whl", hash = "sha256:5340fb95962162cdfdae5cc91d7f8fedd92ed75216c1154c5e1f590fcf56dd0e", size = 10632882, upload-time = "2026-05-13T03:21:52.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Hot-reload manifest schedules

## Summary

Manifest schedules now hot-reload. The manifest directory is rescanned on a
fixed interval (every minute by default), so adding, removing, or editing a
manifest — including changing its `schedule` — takes effect **without
restarting the server**.

Previously, schedules were registered only once at startup: changing a cron
expression or adding/removing a manifest file required a restart, and the
underlying cron library offers no way to update or remove a job after the
scheduler has started.

## Approach

Replaces the one-shot, per-manifest cron registration with a single
every-minute **reconciler** that owns an in-memory registry of manifest
schedules and diffs it against the directory each tick.

- **New pure module `manifest/schedule_registry.py`** — `ScheduleRegistry`
  with a single `reconcile(pairs, now)` method that takes the currently
  present (parsed) manifests plus the current time and returns the actions
  to take. It performs no filesystem or scheduler I/O, so it is fully unit
  tested.
- **Server glue in `server/__init__.py`** — a single `manifest_reconciler`
  cron job (`*/1 * * * *`) calls `reconcile_manifest_schedules()`, which
  scans the directory, applies the diff, logs changes, and launches due /
  newly-added runs. A one-off reconcile also runs at startup so schedules
  register and unscheduled manifests run immediately.

## Behavior

On each scan the reconciler detects and acts on:

- **Added files** — new schedules are registered; new manifests without a
  `schedule` run once.
- **Removed files** — unregistered; they stop firing.
- **Edited `schedule`** — re-read and rescheduled to the new cron (the next
  fire is computed from the change time, not backfilled). Adding a schedule
  to a previously unscheduled manifest starts scheduling it; removing the
  schedule stops it.
- **Due manifests** — fire when their cron is due, then advance to the next
  future occurrence (a single fire, never a catch-up storm).

Robustness:

- A manifest with an invalid cron expression is logged and left unscheduled
  rather than crashing the scheduler.
- A file that is unparseable or introduces a duplicate id mid-edit is
  skipped for that scan (logged) and retried on the next one, so a bad save
  never takes down scheduling. The previous registry is preserved.

## Preserved from the scheduler hardening (#64)

Execution semantics are unchanged and reused by the reconciler:

- **At most one manifest runs at a time** (a process-global lock serializes
  scheduled, startup, and API-triggered runs).
- **Overlapping fires are dropped, not queued** — a scheduled fire is
  skipped while any manifest is running, preventing pile-ups.
- **Single worker process** — the registry and cron state are in memory, so
  scheduling requires the server to run as one worker.

## Configuration

- `SCHEDULER_RECONCILE_CRON` (default `*/1 * * * *`) — how often the
  manifest directory is rescanned.

Existing `SCHEDULER_ENABLED` and `MANIFEST_DIR` are unchanged.

## Dependencies

- `croniter` promoted to an explicit dependency (previously only transitive
  via `fastapi-crons`); it is used to compute next-run times. `uv.lock`
  updated accordingly.

## Testing

- `tests/unit/test_schedule_registry.py` — new, **100% coverage** of the
  registry: add / remove / reschedule detection, due-firing with next-run
  advance, not-due, invalid cron, one-time unscheduled runs, and path
  updates.
- `tests/unit/test_server_scheduling.py` — rewritten for the new API:
  runner skip/lock/error behavior and reconcile add/remove/reschedule/
  one-time-run, plus the global one-at-a-time lock.
- Full unit suite: **873 passed, 100% coverage** (`--cov-fail-under=100`).
- `ruff check` and `ruff format --check`: clean.
- Smoke-checked that the `manifest_reconciler` cron registers when
  `SCHEDULER_ENABLED` is set.



## Test Plan

- [x] Tests pass locally
- [x] Manual testing completed

