### PR TITLE
improve support for extensionless  files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,20 @@
 
 Agents for collecting documents from multiple sources — local filesystems, WebDAV servers, web pages, and source code management platforms (GitHub, Gitea) — and writing them to a local download directory for downstream processing. Each document is written with a `.meta.json` sidecar capturing its MIME type and other metadata, and synchronization state is tracked locally so subsequent runs only fetch what changed.
 
+MIME types are detected from file **content** (via [puremagic](https://pypi.org/project/puremagic/)) rather than trusting the filename extension, and the stored file is given the extension implied by its detected type. This means files with no extension (or the wrong one) are classified correctly and filtered consistently across every source. See [File Typing and Filtering](#file-typing-and-filtering).
+
 ## Features
 
 - **Filesystem Agent (`fs`)**: Ingest documents from local directories
   - Recursive directory scanning
-  - MIME type detection
+  - Content-based MIME type detection (extension-less files supported)
   - Configuration validation
   - Status checking to avoid re-ingesting unchanged files
 
 - **WebDAV Agent (`webdav`)**: Ingest documents from WebDAV servers
   - Support for any WebDAV-compliant server (Nextcloud, ownCloud, SharePoint, etc.)
   - Recursive directory scanning
-  - MIME type detection
+  - MIME type from the server `Content-Type` header, falling back to content sniffing
   - Authentication support (username/password)
   - Status checking to avoid re-ingesting unchanged files
   - URL export for reviewing discovered files before ingestion
@@ -28,7 +30,7 @@ Agents for collecting documents from multiple sources — local filesystems, Web
 
 - **SCM Agent (`scm`)**: Ingest files and issues from Git repositories
   - Support for GitHub and Gitea platforms
-  - Automatic file type filtering
+  - Content-based file type filtering (extension-less files supported)
   - Issue ingestion with comments (rendered as Markdown)
   - Status checking to avoid re-ingesting unchanged files
 
@@ -783,7 +785,7 @@ invocation with `si-agent manifest run <path> --load` / `--no-load`.
    - Filesystem/WebDAV/Web sources: SHA256 hash
    - SCM sources: SHA3-256 hash for files, SHA256 for issues
 3. **Status Check**: The system checks which files are new or changed against the local sync state, so only new or changed files are processed
-4. **Write**: Each file is written to `<DOWNLOAD_DIR>/<source>/<source-relative-path>`, with a `<filename>.meta.json` sidecar containing its MIME type and other metadata
+4. **Write**: Each file is written to `<DOWNLOAD_DIR>/<source>/<source-relative-path>`, with a `<filename>.meta.json` sidecar containing its MIME type and other metadata. The stored filename is given the extension implied by its detected MIME type (added when missing, replaced when it mismatches, left alone when already correct) — see [File Typing and Filtering](#file-typing-and-filtering)
 5. **State Update**: Content hashes (and, for SCM, the latest commit SHA) are recorded in local state
 6. **Stale Removal** (optional): When `delete_stale` is enabled, documents no longer present in the source are deleted from the download directory
 7. **haiku-rag Load** (optional): When `HAIKU_LOAD_ENABLED` is set, the downloaded documents are indexed into a per-source LanceDB database via `haiku-ingester` (see [haiku-rag Loading](#haiku-rag-loading))
@@ -801,25 +803,54 @@ The `run-incremental` command uses commit-based tracking for efficient synchroni
 
 This approach reduces API calls and bandwidth by 80-95% compared to full repository scans. On first run (or after reset), a full sync is performed to establish the baseline.
 
-### File Filtering
+### File Typing and Filtering
 
-Both agents filter files by the `EXTENSIONS` configuration. The default extensions are: `md`, `pdf`, `doc`, `docx`.
+MIME types are determined from file **content**, not the filename. Detection
+resolves in this order:
 
-To add more types:
+1. **Explicit `Content-Type` header** (WebDAV only — the GET response header,
+   or the PROPFIND `getcontenttype` property), unless it is generic
+   (`application/octet-stream`).
+2. **Content sniffing** via [puremagic](https://pypi.org/project/puremagic/),
+   which recognises binary formats (PDF, PNG, Office documents, …) by their
+   magic bytes.
+3. **Filename extension** via the standard library, plus overrides for Office
+   and text formats.
+4. **Plain-text default** (filesystem and git only): an extension-less file
+   whose bytes look like UTF-8 text is treated as `text/plain`. WebDAV does
+   **not** apply this default — it relies on the server-provided type.
+5. Otherwise `application/octet-stream`.
+
+Once typed, the document is written with the extension implied by its MIME
+type (e.g. an extension-less PDF is stored as `<name>.pdf`; an extension-less
+text file on the fs/git agents is stored as `<name>.txt`).
+
+**Detect-then-filter.** Files are filtered by the `EXTENSIONS` configuration
+against their **detected** type, not their original filename. The default
+extensions are `md`, `pdf`, `doc`, `docx`. Extension-less files are no longer
+skipped up front — they are read/downloaded, classified by content, and only
+then filtered. A file survives when the extension implied by its detected MIME
+type is in `EXTENSIONS`.
+
+To add more types (for example, to keep extension-less text files, whose
+detected type is `text/plain` → `txt`):
 
 ```bash
 export EXTENSIONS=md,pdf,doc,docx,txt,rst
 ```
 
-It also validates that files have supported content types and rejects:
+> **Note:** puremagic identifies binary formats by signature but cannot
+> recognise plain text or Markdown (which have no magic bytes); those still
+> resolve via their extension or, on the fs/git agents, the `text/plain`
+> default above.
+
+The `validate-config` / `check-status` commands additionally reject files
+whose recorded content type is an archive or opaque binary:
+
 - ZIP archives
 - RAR archives
 - 7z archives
 - Generic binary files without proper MIME types
-
-#### SCM Agent
-
-The SCM agent only includes files with extensions specified in the `EXTENSIONS` configuration (default: `md`, `pdf`, `doc`, `docx`).
 
 ### Issues as Documents
 
@@ -1291,7 +1322,8 @@ soliplex.agents/
 │   ├── common/              # Shared utilities
 │   │   ├── urls_file.py     # URL list reader (local, S3, WebDAV)
 │   │   ├── s3.py            # S3 object reader
-│   │   └── config.py        # MIME type detection, config helpers
+│   │   ├── mime.py          # Content-based MIME detection + extension logic
+│   │   └── config.py        # Inventory read/validate helpers
 │   ├── fs/                 # Filesystem agent
 │   │   ├── app.py          # Core filesystem logic
 │   │   └── cli.py          # Filesystem CLI commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pyyaml>=6.0",
     "haiku-rag[ingester]>=0.55.1",
     "pypdfium2>=4.0",
+    "puremagic>=2.2.0",
 ]
 
 

--- a/src/soliplex/agents/common/config.py
+++ b/src/soliplex/agents/common/config.py
@@ -2,30 +2,11 @@
 
 import json
 import logging
-import mimetypes
 from pathlib import Path
 
 import aiofiles
 
 from soliplex.agents import ValidationError
-
-# MIME type overrides for Office documents
-MIME_OVERRIDES = {
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",  # noqa: E501
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",  # noqa: E501
-    "application/vnd.openxmlformats-officedocument.presentationml.slideshow": "ppsx",  # noqa: E501
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",  # noqa: E501
-    "text/plantuml": "puml",  # noqa: E501
-    "text/asciidoc": "adoc",
-    "text/svg+xml": "svg",  # noqa: E501
-    "application/x-latex": "latex",  # noqa: E501
-    "text/python": "python",  # noqa: E501
-    "text/yaml": "yaml",  # noqa: E501
-    "text/toml": "toml",
-    "text/json": "json",
-    "text/xml": "xml",
-    "text/javascript": "js",
-}
 
 logger = logging.getLogger(__name__)
 
@@ -65,29 +46,6 @@ def check_config(config: list[dict], start: int = 0, end: int = None) -> list[di
             row["valid"] = False
             row["reason"] = f"Unsupported file extension {ext}"
     return config
-
-
-def detect_mime_type(path: str) -> str:
-    """
-    Detect MIME type for a file path with Office format overrides.
-
-    Args:
-        path: File path to detect MIME type for
-
-    Returns:
-        MIME type string
-    """
-    mime_type = mimetypes.guess_type(str(path))[0]
-    if mime_type is None:
-        # Check if it matches an Office format by extension
-        for mime, ext in MIME_OVERRIDES.items():
-            if path.endswith(ext):
-                return mime  # pragma: no cover
-        if "/issues/" in path:  # pragma: no cover
-            return "text/markdown"  # issues don't have mime types so use markdown
-        logger.error(f"unrecognized mime type for {path}")
-        mime_type = "application/octet-stream"
-    return mime_type
 
 
 async def read_config(config_path: str) -> list[dict]:

--- a/src/soliplex/agents/common/mime.py
+++ b/src/soliplex/agents/common/mime.py
@@ -1,0 +1,203 @@
+"""Single source of truth for MIME-type detection and file-extension logic.
+
+Detection prefers, in order: an explicit content-type header (e.g. WebDAV's
+``getcontenttype`` / GET ``Content-Type``), content sniffing via
+:mod:`puremagic` (magic bytes), the filename extension, and finally a
+fallback.
+
+:mod:`puremagic` classifies binary formats by their magic signature but
+cannot recognise plain text or Markdown (which carry none); such files
+resolve via their extension. For sources without an authoritative header
+(filesystem, git), callers pass ``text_fallback=True`` so an extension-less
+file whose bytes look like UTF-8 text is treated as ``text/plain`` (written
+``.txt``) rather than opaque ``application/octet-stream``. WebDAV does not
+use that default -- it relies on the server-provided content type, so an
+extension-less WebDAV file with no usable header stays
+``application/octet-stream``.
+"""
+
+import logging
+import mimetypes
+from pathlib import Path
+from pathlib import PurePosixPath
+
+import puremagic
+
+logger = logging.getLogger(__name__)
+
+# MIME type -> canonical extension (dot included) where
+# ``mimetypes.guess_extension`` is unhelpful (e.g. ".markdown" not ".md").
+_EXT_OVERRIDES = {
+    "text/markdown": ".md",
+    "text/html": ".html",
+    "text/plain": ".txt",
+}
+
+# Extension overrides for MIME types the stdlib doesn't know, used when
+# ``mimetypes.guess_type`` returns ``None`` for a path. Maps MIME -> the
+# bare extension that identifies it.
+MIME_OVERRIDES = {
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",  # noqa: E501
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",  # noqa: E501
+    "application/vnd.openxmlformats-officedocument.presentationml.slideshow": "ppsx",  # noqa: E501
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",  # noqa: E501
+    "text/plantuml": "puml",
+    "text/asciidoc": "adoc",
+    "text/svg+xml": "svg",
+    "application/x-latex": "latex",
+    "text/python": "python",
+    "text/yaml": "yaml",
+    "text/toml": "toml",
+    "text/json": "json",
+    "text/xml": "xml",
+    "text/javascript": "js",
+}
+
+# Content types that carry no useful information -- treat as "unknown" so we
+# fall through to sniffing / extension rather than trusting them.
+_GENERIC_TYPES = frozenset({"", "application/octet-stream", "binary/octet-stream"})
+
+# Bytes inspected when deciding whether content is plausibly text.
+_TEXT_SNIFF_BYTES = 8192
+
+
+def _normalize(mime_type: str) -> str:
+    """Lower-case a MIME type and drop any ``; charset=...`` parameters."""
+    return mime_type.split(";")[0].strip().lower()
+
+
+def sniff_bytes(data: bytes | None) -> str | None:
+    """Return a MIME type detected from *data*'s magic bytes, or ``None``.
+
+    Returns ``None`` for empty input and for content puremagic can't
+    identify (plain text, Markdown, and other signature-less formats).
+    """
+    if not data:
+        return None
+    try:
+        guessed = puremagic.from_string(data, mime=True)
+    except (puremagic.PureError, ValueError):
+        return None
+    return guessed or None
+
+
+def _looks_like_text(data: bytes | None) -> bool:
+    """Return ``True`` when *data* is plausibly UTF-8 text.
+
+    Rejects content containing NUL bytes and content whose leading chunk
+    isn't valid UTF-8 (tolerating a multi-byte sequence split at the chunk
+    boundary).
+    """
+    if not data:
+        return False
+    chunk = data[:_TEXT_SNIFF_BYTES]
+    if b"\x00" in chunk:
+        return False
+    try:
+        chunk.decode("utf-8")
+    except UnicodeDecodeError:
+        # The chunk boundary may bisect a multi-byte character; retry with
+        # up to three trailing bytes trimmed before giving up.
+        for back in (1, 2, 3):
+            try:
+                chunk[:-back].decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            else:
+                return True
+        return False
+    return True
+
+
+def detect_mime_type(
+    path: str,
+    *,
+    data: bytes | None = None,
+    header_type: str | None = None,
+    text_fallback: bool = False,
+) -> str:
+    """Resolve a MIME type for *path* from the best available signal.
+
+    Precedence: an explicit ``header_type`` (unless generic) > content
+    sniffing of ``data`` > the filename extension > (when *text_fallback*
+    is set and ``data`` looks like text) ``text/plain`` >
+    ``application/octet-stream``.
+    """
+    if header_type:
+        norm = _normalize(header_type)
+        if norm and norm not in _GENERIC_TYPES:
+            return norm
+
+    sniffed = sniff_bytes(data)
+    if sniffed:
+        return sniffed
+
+    path_str = str(path)
+    mime_type = mimetypes.guess_type(path_str)[0]
+    if mime_type:
+        return mime_type
+
+    for mime, ext in MIME_OVERRIDES.items():
+        if path_str.endswith(ext):
+            return mime
+
+    if "/issues/" in path_str:
+        # Rendered git issues have no MIME type; treat as Markdown.
+        return "text/markdown"
+
+    if text_fallback and _looks_like_text(data):
+        return "text/plain"
+
+    logger.debug("unrecognized mime type for %s", path_str)
+    return "application/octet-stream"
+
+
+def guess_extension(mime_type: str | None) -> str:
+    """Return a file extension (including the dot) for *mime_type*, or ``""``."""
+    if not mime_type:
+        return ""
+    mt = _normalize(mime_type)
+    if mt in _EXT_OVERRIDES:
+        return _EXT_OVERRIDES[mt]
+    return mimetypes.guess_extension(mt) or ""
+
+
+def ensure_extension(name: str, mime_type: str | None) -> str:
+    """Return *name* carrying the extension implied by *mime_type*.
+
+    Adds an extension when *name* has none, replaces one that clearly
+    mismatches, and keeps one that is already correct (or already resolves
+    to the same MIME type, e.g. ``.htm`` for ``text/html``).
+    """
+    want = guess_extension(mime_type)
+    if not want:
+        return name
+    suffix = PurePosixPath(name).suffix
+    cur = suffix.lower()
+    if cur == want:
+        return name
+    if cur and mimetypes.guess_type(name)[0] == _normalize(mime_type):
+        return name
+    if not cur:
+        return name + want
+    return name[: -len(suffix)] + want
+
+
+def extension_allowed(mime_type: str | None, allowed_extensions: list[str]) -> bool:
+    """Return ``True`` when *mime_type*'s extension is in *allowed_extensions*."""
+    return guess_extension(mime_type).lstrip(".") in allowed_extensions
+
+
+def passes_extension_prefilter(name: str, allowed_extensions: list[str] | None) -> bool:
+    """Return ``True`` when *name* should be fetched for content typing.
+
+    A coarse pre-download gate: files whose extension is in
+    *allowed_extensions* pass, and so do extension-less files (their real
+    type is only known once their bytes are sniffed). Files carrying a
+    disallowed extension are dropped without downloading. The authoritative
+    filter runs later against the detected MIME type (:func:`extension_allowed`).
+    """
+    if allowed_extensions is None:
+        return True
+    ext = Path(name).suffix.lstrip(".")
+    return not ext or ext in allowed_extensions

--- a/src/soliplex/agents/common/urls_file.py
+++ b/src/soliplex/agents/common/urls_file.py
@@ -81,7 +81,7 @@ async def read_text_from_webdav(
 
     client = create_async_webdav_client(base_url, webdav_username, webdav_password)
     async with client:
-        content = await client.download(path)
+        content, _content_type = await client.download(path)
     return content.decode("utf-8")
 
 

--- a/src/soliplex/agents/fs/app.py
+++ b/src/soliplex/agents/fs/app.py
@@ -9,8 +9,9 @@ import aiofiles.os as aos
 from soliplex.agents import local_state
 from soliplex.agents import local_store
 from soliplex.agents.common.config import check_config
-from soliplex.agents.common.config import detect_mime_type
 from soliplex.agents.common.config import read_config
+from soliplex.agents.common.mime import detect_mime_type
+from soliplex.agents.common.mime import extension_allowed
 from soliplex.agents.config import settings
 
 logger = logging.getLogger(__name__)
@@ -84,18 +85,20 @@ async def build_config(source_dir) -> list[dict]:
     allowed_extensions = settings.extensions
     config = []
     for path in paths:
-        ext = path.suffix.lstrip(".")
-        if ext not in allowed_extensions and not path.is_dir():
-            logger.info(f"skipping {path}")
-            continue
         try:
+            body = path.read_bytes()
             adj_path = path.relative_to(Path(source_dir))
-            mime_type = detect_mime_type(str(adj_path))
+            # Detect from content (extension-less text -> text/plain), then
+            # filter by the detected MIME type rather than the filename.
+            mime_type = detect_mime_type(str(adj_path), data=body, text_fallback=True)
+            if not extension_allowed(mime_type, allowed_extensions):
+                logger.info(f"skipping {path} (detected {mime_type})")
+                continue
             rec = {
                 "path": str(adj_path),
-                "sha256": hashlib.sha256(path.read_bytes(), usedforsecurity=False).hexdigest(),
+                "sha256": hashlib.sha256(body, usedforsecurity=False).hexdigest(),
                 "metadata": {
-                    "size": path.stat().st_size,
+                    "size": len(body),
                     "content-type": mime_type,
                 },
             }
@@ -172,7 +175,7 @@ async def load_inventory(
             if extra_metadata:
                 meta.update(extra_metadata)
             logger.info(f"writing {uri}")
-            mime_type = (row.get("metadata") or {}).get("content-type") or detect_mime_type(uri)
+            mime_type = (row.get("metadata") or {}).get("content-type")
             await _write_local(data_path, uri, meta, source, mime_type, row.get("sha256"))
             ingested.append(uri)
         except Exception as e:
@@ -191,13 +194,17 @@ async def _write_local(
     uri: str,
     meta: dict[str, str],
     source: str,
-    mime_type: str,
+    mime_type: str | None,
     sha256: str | None,
 ):
     """Read a source file and write it (plus its sidecar) to the download dir."""
     load_path = uri if uri.startswith("/") else data_path / uri
     async with aiofiles.open(load_path, "rb") as f:
         doc_body = await f.read()
+    # When the inventory row carried no (or a generic) content type, detect
+    # it from the bytes, defaulting extension-less text to text/plain.
+    if not mime_type or mime_type == "application/octet-stream":
+        mime_type = detect_mime_type(uri, data=doc_body, text_fallback=True)
     local_store.write_document(source, uri, doc_body, mime_type, meta)
     local_state.upsert_file(source, uri, sha256, size=len(doc_body), mime_type=mime_type)
 

--- a/src/soliplex/agents/local_store.py
+++ b/src/soliplex/agents/local_store.py
@@ -10,12 +10,13 @@ type and any other available metadata.
 import hashlib
 import json
 import logging
-import mimetypes
 import re
 from pathlib import Path
 from urllib.parse import unquote
 from urllib.parse import urlsplit
 
+from soliplex.agents.common.mime import ensure_extension
+from soliplex.agents.common.mime import guess_extension
 from soliplex.agents.config import settings
 
 logger = logging.getLogger(__name__)
@@ -37,14 +38,6 @@ _RESERVED_NAMES = frozenset(
         *(f"LPT{i}" for i in range(1, 10)),
     }
 )
-
-# Preferred extensions for MIME types where guess_extension is unhelpful
-# (e.g. it returns ".markdown" rather than ".md").
-_EXT_OVERRIDES = {
-    "text/markdown": ".md",
-    "text/html": ".html",
-    "text/plain": ".txt",
-}
 
 
 def sanitize_source(source: str) -> str:
@@ -76,37 +69,16 @@ def _sanitize_segment(segment: str) -> str:
     return cleaned
 
 
-def _guess_ext(mime_type: str | None) -> str:
-    """Return a file extension (including the dot) for a MIME type, or ``""``."""
-    if not mime_type:
-        return ""
-    mt = mime_type.split(";")[0].strip().lower()
-    if mt in _EXT_OVERRIDES:
-        return _EXT_OVERRIDES[mt]
-    return mimetypes.guess_extension(mt) or ""
-
-
-def needs_extension(uri: str) -> bool:
-    """Return True when *uri* names content that may lack a real extension.
-
-    Web URLs (HTML pages) and git issues are written from rendered content
-    whose URI often has no file extension; everything else (repo files,
-    filesystem paths, WebDAV paths) already carries one. Deriving this
-    purely from the URI keeps :func:`write_document` and
-    :func:`delete_document` symmetric without the caller tracking a flag.
-    """
-    return urlsplit(uri.strip()).scheme in ("http", "https") or "/issues/" in uri
-
-
 def uri_to_relpath(uri: str, *, mime_type: str | None = None) -> Path:
     """Map a source URI to a safe relative path under the source directory.
 
     Preserves the source directory structure where possible. URLs are
     mapped to ``host/path`` and gain a synthesized filename when they end
-    in ``/``. Path traversal segments (``..``) are dropped. When the URI
-    names extension-less content (see :func:`needs_extension`) and the
-    final segment has no extension, one is derived from ``mime_type``
-    (e.g. git issues -> ``.md``).
+    in ``/``. Path traversal segments (``..``) are dropped. The final
+    segment's extension is reconciled against ``mime_type`` for every
+    source (see :func:`~soliplex.agents.common.mime.ensure_extension`):
+    an extension is added when missing, replaced when it clearly
+    mismatches, and left alone when already correct.
 
     Args:
         uri: Source URI or path (e.g. ``"docs/readme.md"``,
@@ -136,9 +108,9 @@ def uri_to_relpath(uri: str, *, mime_type: str | None = None) -> Path:
         no_filename = False
 
     if no_filename:
-        rel_segs.append("index" + _guess_ext(mime_type))
-    elif needs_extension(raw) and "." not in rel_segs[-1]:
-        rel_segs[-1] = rel_segs[-1] + _guess_ext(mime_type)
+        rel_segs.append("index" + guess_extension(mime_type))
+    else:
+        rel_segs[-1] = ensure_extension(rel_segs[-1], mime_type)
 
     return Path(*rel_segs)
 

--- a/src/soliplex/agents/manifest/haiku_loader.py
+++ b/src/soliplex/agents/manifest/haiku_loader.py
@@ -178,7 +178,7 @@ async def run_load(manifest: Manifest) -> dict:
         async with asyncio.timeout(settings.haiku_load_timeout):
             out, err = await asyncio.gather(
                 _pump_stream(proc.stdout, logger.info, source),
-                _pump_stream(proc.stderr, logger.warning, source),
+                _pump_stream(proc.stderr, logger.info, source),
             )
             await proc.wait()
     except TimeoutError:

--- a/src/soliplex/agents/scm/app.py
+++ b/src/soliplex/agents/scm/app.py
@@ -2,8 +2,9 @@ import datetime
 import hashlib
 import logging
 
-from soliplex.agents.common.config import detect_mime_type
+from soliplex.agents.common import mime
 from soliplex.agents.scm.base import BaseSCMProvider
+from soliplex.agents.scm.base import passes_extension_prefilter
 
 from .. import local_state
 from .. import local_store
@@ -62,11 +63,15 @@ def _doc_meta(row: dict, extra_metadata: dict[str, str] | None) -> dict:
 
 
 def _resolve_mime(row: dict) -> str:
-    """Resolve the MIME type for a row from its metadata or its URI."""
+    """Resolve the MIME type for a row from its metadata, content, or URI."""
     ct = row.get("content-type") or (row.get("metadata") or {}).get("content-type")
     if ct:
         return ct
-    return detect_mime_type(row.get("uri") or row.get("path"))
+    return mime.detect_mime_type(
+        row.get("uri") or row.get("path"),
+        data=row.get("file_bytes"),
+        text_fallback=True,
+    )
 
 
 async def load_inventory(
@@ -173,7 +178,7 @@ async def list_all_uris(
             branch=branch,
         )
         for f in files:
-            if f["name"].split(".")[-1] in allowed_extensions:
+            if mime.extension_allowed(f.get("content-type"), allowed_extensions):
                 items.append({"uri": f["uri"], "sha256": f.get("sha256", "")})
 
     if content_filter in (ContentFilter.ALL, ContentFilter.ISSUES):
@@ -214,7 +219,7 @@ async def get_data(scm: str, repo_name: str, owner: str = None, content_filter: 
             files = sorted(files, key=lambda x: x.get("last_updated"), reverse=True)
         except Exception as e:
             logger.exception("Error sorting files", exc_info=e)
-        filtered_files = [x for x in files if x["name"].split(".")[-1] in allowed_extensions]
+        filtered_files = [x for x in files if mime.extension_allowed(x.get("content-type"), allowed_extensions)]
         for f in filtered_files:
             row = {
                 "file_bytes": f["file_bytes"],
@@ -363,20 +368,24 @@ async def incremental_sync(
 
         logger.info(f"Files changed: {len(changed_files)}, removed: {len(removed_files)}")
 
-        # Delete removed files locally
+        # Delete removed files locally. Pass the stored mime_type so the
+        # synthesized-extension path round-trips (delete_document recomputes
+        # the relpath from the URI + mime_type).
+        removed_state = local_state.load_file_state(source)
         for removed_path in removed_files:
             logger.info(f"Deleting removed file: {removed_path}")
-            local_store.delete_document(source, removed_path)
+            removed_mime = removed_state.get(removed_path, {}).get("mime_type")
+            local_store.delete_document(source, removed_path, mime_type=removed_mime)
             local_state.delete_file(source, removed_path)
 
-        # Fetch only changed files
+        # Fetch changed files. Use a coarse extension pre-filter (allowed
+        # extension or none); the authoritative filter runs after fetch
+        # against the content-detected MIME type.
         allowed_extensions = settings.extensions
 
         for file_path in changed_files:
-            # Check if extension is allowed
-            ext = file_path.split(".")[-1] if "." in file_path else ""
-            if ext not in allowed_extensions:
-                logger.debug(f"Skipping {file_path} - extension '{ext}' not in allowed list")
+            if not passes_extension_prefilter(file_path, allowed_extensions):
+                logger.debug(f"Skipping {file_path} - extension not in allowed list")
                 continue
 
             try:
@@ -385,6 +394,9 @@ async def incremental_sync(
             except Exception as e:
                 fetch_errors = True
                 logger.exception(f"Failed to fetch {file_path}", exc_info=e)
+
+        # Drop fetched files whose detected content type isn't allowed.
+        file_data = [f for f in file_data if mime.extension_allowed(_resolve_mime(f), allowed_extensions)]
 
         logger.info(f"Fetched {len(file_data)} changed files with allowed extensions")
     elif not issues:

--- a/src/soliplex/agents/scm/base.py
+++ b/src/soliplex/agents/scm/base.py
@@ -4,19 +4,19 @@ import asyncio
 import base64
 import datetime
 import logging
-import mimetypes
 import random
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import AsyncIterator
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Any
 
 import aiohttp
 from tenacity import AsyncRetrying
 
+from soliplex.agents.common import mime
+from soliplex.agents.common.mime import passes_extension_prefilter
 from soliplex.agents.config import settings
 from soliplex.agents.retry import RETRYABLE_STATUS_CODES
 from soliplex.agents.retry import RetryableHTTPError
@@ -292,7 +292,7 @@ class BaseSCMProvider(ABC):
             "path": uri,
             "file_bytes": file_bytes,
             "sha256": file_hash,
-            "content-type": mimetypes.guess_type(rec["name"])[0],
+            "content-type": mime.detect_mime_type(rec["name"], data=file_bytes, text_fallback=True),
             "last_updated": self.get_last_updated(rec),
             "last_commit_sha": rec["last_commit_sha"],
         }
@@ -395,7 +395,7 @@ class BaseSCMProvider(ABC):
                 # This is a directory, recursively fetch all files
                 parsed = []
                 for r in res:
-                    if allowed_extensions is None or Path(r["name"]).suffix.lstrip(".") in allowed_extensions:
+                    if passes_extension_prefilter(r["name"], allowed_extensions):
                         logger.debug(f"fetching file in dir for url = {r['url']}")
                         parsed.append(
                             await self.get_data_from_url(r["url"], session, owner, repo, allowed_extensions, semaphore)
@@ -464,7 +464,7 @@ class BaseSCMProvider(ABC):
                 tasks = [
                     self.get_data_from_url(file["url"], session, owner, repo, None, semaphore)
                     for file in files
-                    if Path(file["name"]).suffix.lstrip(".") in allowed_extensions
+                    if passes_extension_prefilter(file["name"], allowed_extensions)
                 ]
                 for dir in dirs:
                     tasks.append(self.get_data_from_url(dir["url"], session, owner, repo, allowed_extensions, semaphore))

--- a/src/soliplex/agents/scm/git_cli.py
+++ b/src/soliplex/agents/scm/git_cli.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import mimetypes
 import re
 import shutil
 import tempfile
@@ -11,10 +10,12 @@ from typing import Any
 
 import aiofiles
 
+from soliplex.agents.common import mime
 from soliplex.agents.config import settings
 from soliplex.agents.scm import AuthenticationConfigError
 from soliplex.agents.scm import SCMException
 from soliplex.agents.scm.base import BaseSCMProvider
+from soliplex.agents.scm.base import passes_extension_prefilter
 from soliplex.agents.scm.lib.utils import compute_file_hash
 
 logger = logging.getLogger(__name__)
@@ -661,7 +662,7 @@ class GitCliDecorator(BaseSCMProvider):
             "url": "",  # No API URL for local files
             "file_bytes": content,
             "sha256": compute_file_hash(content),
-            "content-type": mimetypes.guess_type(full_path.name)[0],
+            "content-type": mime.detect_mime_type(full_path.name, data=content, text_fallback=True),
             "last_updated": commit_info["date"],
             "last_commit_sha": commit_info["sha"],
         }
@@ -681,18 +682,22 @@ class GitCliDecorator(BaseSCMProvider):
         repo_dir = await self._ensure_repo_cloned(repo, owner, branch)
 
         files = []
-        for ext in allowed_extensions:
-            for file_path in repo_dir.rglob(f"*.{ext}"):
-                # Skip .git directory
-                if ".git" in file_path.parts:
-                    continue
+        for file_path in repo_dir.rglob("*"):
+            # Skip directories and the .git directory
+            if not file_path.is_file() or ".git" in file_path.parts:
+                continue
+            # Coarse pre-filter: allowed extension or no extension (the real
+            # type is decided from content in _read_local_file); the
+            # authoritative filter runs later against the detected MIME type.
+            if not passes_extension_prefilter(file_path.name, allowed_extensions):
+                continue
 
-                rel_path = str(file_path.relative_to(repo_dir)).replace("\\", "/")
-                try:
-                    file_data = await self._read_local_file(repo_dir, rel_path)
-                    files.append(file_data)
-                except Exception as e:
-                    logger.warning(f"Failed to read {rel_path}: {e}")
+            rel_path = str(file_path.relative_to(repo_dir)).replace("\\", "/")
+            try:
+                file_data = await self._read_local_file(repo_dir, rel_path)
+                files.append(file_data)
+            except Exception as e:
+                logger.warning(f"Failed to read {rel_path}: {e}")
 
         logger.info(f"Found {len(files)} files in local clone of {owner}/{repo}")
         return files

--- a/src/soliplex/agents/webdav/app.py
+++ b/src/soliplex/agents/webdav/app.py
@@ -10,7 +10,9 @@ import aiohttp
 from soliplex.agents import local_state
 from soliplex.agents import local_store
 from soliplex.agents.common.config import check_config
-from soliplex.agents.common.config import detect_mime_type
+from soliplex.agents.common.mime import detect_mime_type
+from soliplex.agents.common.mime import extension_allowed
+from soliplex.agents.common.mime import passes_extension_prefilter
 from soliplex.agents.config import settings
 from soliplex.agents.webdav.async_client import AsyncWebDAVClient
 from soliplex.agents.webdav.async_client import ResourceNotFound
@@ -171,9 +173,11 @@ async def build_config_from_urls(
 
     async with webdav_client:
         for full_path in lines:
-            ext = Path(full_path).suffix.lstrip(".")
-            if ext not in allowed_extensions:
+            # Coarse pre-filter: allowed extension or none (extension-less
+            # files are typed from the server header / content at download).
+            if not passes_extension_prefilter(full_path, allowed_extensions):
                 logger.info(f"skipping {full_path}")
+                ext = Path(full_path).suffix.lstrip(".")
                 results.append({"url": full_path, "status": "skipped", "error_message": f"Extension .{ext} not allowed"})
                 continue
 
@@ -182,10 +186,12 @@ async def build_config_from_urls(
                 # last-modified (this server omits ETags but sends modified).
                 server_etag = None
                 modified = None
+                server_content_type = None
                 try:
                     info = await webdav_client.info(full_path)
                     server_etag = info.get("etag")
                     modified = info.get("modified")
+                    server_content_type = info.get("content_type")
                 except Exception:
                     logger.debug("Could not get info for %s", full_path, exc_info=True)
                 if not server_etag:
@@ -194,6 +200,8 @@ async def build_config_from_urls(
                         server_etag = resp.headers.get("etag")
                         if not modified:
                             modified = resp.headers.get("last-modified")
+                        if not server_content_type:
+                            server_content_type = resp.headers.get("content-type")
                     except Exception:
                         logger.debug("Could not HEAD %s", full_path, exc_info=True)
 
@@ -204,7 +212,10 @@ async def build_config_from_urls(
                     logger.debug("no etag or last-modified for %s -- will re-download every run", full_path)
 
                 cached_entry = cached_state.get(full_path)
-                mime_type = detect_mime_type(full_path)
+                # Provisional type from the server header (falls back to the
+                # extension). The authoritative type is resolved from headers
+                # + content at download time in do_ingest.
+                mime_type = detect_mime_type(full_path, header_type=server_content_type)
 
                 if server_token and cached_entry and cached_entry.get("etag") == server_token:
                     # Cache hit — reuse cached SHA256, no download
@@ -266,13 +277,18 @@ async def list_config(
 
     for file_info in files:
         full_path = file_info["path"]
-        ext = Path(full_path).suffix.lstrip(".")
 
-        if ext not in allowed_extensions:
+        if not passes_extension_prefilter(full_path, allowed_extensions):
             logger.info(f"skipping {full_path}")
             continue
 
-        mime_type = detect_mime_type(full_path)
+        mime_type = detect_mime_type(full_path, header_type=file_info.get("content_type"))
+        # Drop only positively-identified disallowed types. An indeterminate
+        # type (octet-stream: no header, no extension) is deferred so it can
+        # be sniffed from content when the file is downloaded for ingestion.
+        if mime_type != "application/octet-stream" and not extension_allowed(mime_type, allowed_extensions):
+            logger.info(f"skipping {full_path} (detected {mime_type})")
+            continue
 
         normalized_base = webdav_path.strip("/")
         normalized_full = full_path.strip("/")
@@ -342,14 +358,14 @@ async def build_config(
 
         for file_info in files:
             full_path = file_info["path"]  # This is the absolute WebDAV path
-            ext = Path(full_path).suffix.lstrip(".")
 
-            if ext not in allowed_extensions:
+            if not passes_extension_prefilter(full_path, allowed_extensions):
                 logger.info(f"skipping {full_path}")
                 continue
 
             server_etag = file_info.get("etag")
             modified = file_info.get("modified")
+            server_content_type = file_info.get("content_type")
             etag_source = "listing"
             if not server_etag:
                 etag_source = "HEAD"
@@ -358,8 +374,19 @@ async def build_config(
                     server_etag = resp.headers.get("etag")
                     if not modified:
                         modified = resp.headers.get("last-modified")
+                    if not server_content_type:
+                        server_content_type = resp.headers.get("content-type")
                 except Exception:
                     logger.debug("Could not HEAD %s", full_path, exc_info=True)
+
+            # Provisional type from the server header (else extension).
+            # Indeterminate types (octet-stream) are deferred to do_ingest,
+            # which sniffs the downloaded content; positively-identified
+            # disallowed types are dropped here without downloading.
+            mime_type = detect_mime_type(full_path, header_type=server_content_type)
+            if mime_type != "application/octet-stream" and not extension_allowed(mime_type, allowed_extensions):
+                logger.info(f"skipping {full_path} (detected {mime_type})")
+                continue
 
             # Validator: strong ETag if present, else last-modified timestamp.
             server_token, token_source = _version_token(server_etag, modified)
@@ -415,8 +442,6 @@ async def build_config(
                 else:
                     miss_reason = f"validator changed (cached={cached_entry.get('etag')!r}, server={server_token!r})"
                 logger.debug("cache MISS for %s: %s", relative_path, miss_reason)
-
-            mime_type = detect_mime_type(full_path)
 
             rec = {
                 "path": relative_path,
@@ -551,7 +576,9 @@ async def load_inventory(
             meta = _doc_meta(row, extra_metadata)
             etag = row.get("_etag")
             logger.info(f"writing {uri} {idx + 1}/{len(to_process)}")
-            mime_type = (row.get("metadata") or {}).get("content-type") or detect_mime_type(uri)
+            # Provisional type from discovery; do_ingest resolves the final
+            # type from the GET Content-Type header and content sniffing.
+            mime_type = (row.get("metadata") or {}).get("content-type")
             res = await do_ingest(
                 base_path,
                 uri,
@@ -566,6 +593,8 @@ async def load_inventory(
             if "error" in res:
                 logger.error(f"Error writing {uri}: {res['error']}")
                 errors.append({"uri": uri, "error": res["error"]})
+            elif res.get("skipped"):
+                logger.info("skipping %s: %s", uri, res["skipped"])
             else:
                 ingested.append(uri)
         except Exception as e:
@@ -598,17 +627,21 @@ async def do_ingest(
         uri: Relative file path
         meta: File metadata for the sidecar
         source: Source identifier
-        mime_type: MIME type of the file
+        mime_type: Provisional MIME type from discovery (may be ``None``);
+            the final type is resolved from the GET ``Content-Type`` header
+            and content sniffing.
         webdav_url: Optional WebDAV server URL
         webdav_username: Optional WebDAV username
         webdav_password: Optional WebDAV password
         etag: Server ETag to record in local state, if known
 
     Returns:
-        Result dictionary with success/error information
+        Result dictionary with success/error information (or a ``skipped``
+        reason when the resolved content type is not allowed).
     """
     logger.info(f"base_path={base_path}, uri={uri}")
 
+    header_type = None
     # Check if base_path is a local directory
     if base_path and Path(base_path).exists():
         load_path = Path(base_path) / uri
@@ -621,7 +654,7 @@ async def do_ingest(
             full_path = f"{base_path.rstrip('/')}/{uri.lstrip('/')}" if base_path else uri
             logger.info(f"Downloading from WebDAV: {full_path}")
             async with webdav_client:
-                doc_body = await webdav_client.download(full_path)
+                doc_body, header_type = await webdav_client.download(full_path)
         except Exception as e:
             logger.exception(f"Error downloading {uri} from WebDAV")
             return {"error": str(e)}
@@ -641,6 +674,20 @@ async def do_ingest(
                 logger.debug("do_ingest HEAD validator for %s via %s: %s", uri, token_source, etag)
             except Exception:
                 logger.debug("Could not get validator via HEAD for %s", uri, exc_info=True)
+
+    # Resolve the final type: server GET header wins, then content sniffing,
+    # then the filename extension. WebDAV relies on the server's mime type,
+    # so no plain-text (.txt) fallback is applied. The provisional type from
+    # discovery (e.g. a PROPFIND getcontenttype) is used only when nothing
+    # else identifies the content.
+    resolved = detect_mime_type(uri, data=doc_body, header_type=header_type)
+    if resolved == "application/octet-stream" and mime_type:
+        resolved = mime_type
+    mime_type = resolved
+    if not extension_allowed(mime_type, settings.extensions):
+        reason = f"content type {mime_type} not allowed"
+        logger.info("skipping %s: %s", uri, reason)
+        return {"skipped": reason, "uri": uri}
 
     sha256_hash = hashlib.sha256(doc_body, usedforsecurity=False).hexdigest()
     local_store.write_document(source, uri, doc_body, mime_type, meta)

--- a/src/soliplex/agents/webdav/async_client.py
+++ b/src/soliplex/agents/webdav/async_client.py
@@ -535,8 +535,13 @@ class AsyncWebDAVClient:
         resp.release()
         return WebDAVResponse(status=status, headers=headers)
 
-    async def download(self, path: str) -> bytes:
-        """Download a file via HTTP GET. Returns the file content as bytes."""
+    async def download(self, path: str) -> tuple[bytes, str | None]:
+        """Download a file via HTTP GET.
+
+        Returns ``(content, content_type)`` where ``content_type`` is the
+        server's ``Content-Type`` header (``None`` when absent), used to type
+        the document ahead of content sniffing.
+        """
         resp = await self._request(
             "GET",
             path,
@@ -544,8 +549,9 @@ class AsyncWebDAVClient:
             timeout=aiohttp.ClientTimeout(total=300, connect=20),
         )
         content = await resp.read()
+        content_type = resp.headers.get("Content-Type")
         resp.release()
-        return content
+        return content, content_type
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_async_webdav_client.py
+++ b/tests/unit/test_async_webdav_client.py
@@ -928,11 +928,26 @@ class TestHead:
 
 class TestDownload:
     @pytest.mark.asyncio
-    async def test_download_returns_bytes(self):
+    async def test_download_returns_bytes_and_content_type(self):
         client, session = _make_client()
-        session.request = AsyncMock(return_value=_mock_response(200, content=b"file content here"))
-        result = await client.download("/file.txt")
-        assert result == b"file content here"
+        session.request = AsyncMock(
+            return_value=_mock_response(
+                200,
+                content=b"file content here",
+                headers={"Content-Type": "text/plain"},
+            )
+        )
+        content, content_type = await client.download("/file.txt")
+        assert content == b"file content here"
+        assert content_type == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_download_content_type_none_when_absent(self):
+        client, session = _make_client()
+        session.request = AsyncMock(return_value=_mock_response(200, content=b"data"))
+        content, content_type = await client.download("/file.txt")
+        assert content == b"data"
+        assert content_type is None
 
     @pytest.mark.asyncio
     async def test_download_follows_redirects(self):

--- a/tests/unit/test_common_config.py
+++ b/tests/unit/test_common_config.py
@@ -5,9 +5,7 @@ import json
 import pytest
 
 from soliplex.agents import ValidationError
-from soliplex.agents.common.config import MIME_OVERRIDES
 from soliplex.agents.common.config import check_config
-from soliplex.agents.common.config import detect_mime_type
 from soliplex.agents.common.config import read_config
 
 
@@ -165,87 +163,6 @@ class TestCheckConfig:
         result = check_config(config, start=0, end=10)
         assert len(result) == 1
         assert result[0]["valid"] is True
-
-
-class TestDetectMimeType:
-    """Tests for detect_mime_type function."""
-
-    def test_detect_mime_type_standard_file(self):
-        """Test detect_mime_type with standard file type."""
-        mime_type = detect_mime_type("test.pdf")
-        assert mime_type == "application/pdf"
-
-    def test_detect_mime_type_text_file(self):
-        """Test detect_mime_type with text file."""
-        mime_type = detect_mime_type("readme.txt")
-        assert mime_type == "text/plain"
-
-    def test_detect_mime_type_markdown(self):
-        """Test detect_mime_type with markdown file."""
-        mime_type = detect_mime_type("doc.md")
-        # Markdown files may not be recognized by mimetypes
-        assert mime_type in ["text/markdown", "text/x-markdown", "application/octet-stream"]
-
-    def test_detect_mime_type_docx_override(self):
-        """Test detect_mime_type with .docx file using MIME override."""
-        mime_type = detect_mime_type("document.docx")
-        expected = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        assert mime_type == expected
-
-    def test_detect_mime_type_xlsx_override(self):
-        """Test detect_mime_type with .xlsx file using MIME override."""
-        mime_type = detect_mime_type("spreadsheet.xlsx")
-        expected = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        assert mime_type == expected
-
-    def test_detect_mime_type_pptx_override(self):
-        """Test detect_mime_type with .pptx file using MIME override."""
-        mime_type = detect_mime_type("presentation.pptx")
-        expected = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        assert mime_type == expected
-
-    def test_detect_mime_type_unknown_extension(self):
-        """Test detect_mime_type with unknown extension."""
-        mime_type = detect_mime_type("file.unknownext")
-        assert mime_type == "application/octet-stream"
-
-    def test_detect_mime_type_no_extension(self):
-        """Test detect_mime_type with file without extension."""
-        mime_type = detect_mime_type("filename")
-        assert mime_type == "application/octet-stream"
-
-    def test_detect_mime_type_path_with_directory(self):
-        """Test detect_mime_type with full path."""
-        mime_type = detect_mime_type("/path/to/document.docx")
-        expected = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        assert mime_type == expected
-
-
-class TestMimeOverrides:
-    """Tests for MIME_OVERRIDES constant."""
-
-    def test_mime_overrides_exists(self):
-        """Test MIME_OVERRIDES constant exists."""
-        assert MIME_OVERRIDES is not None
-        assert isinstance(MIME_OVERRIDES, dict)
-
-    def test_mime_overrides_has_office_formats(self):
-        """Test MIME_OVERRIDES includes Office formats."""
-        assert "application/vnd.openxmlformats-officedocument.wordprocessingml.document" in MIME_OVERRIDES
-        assert "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" in MIME_OVERRIDES
-        assert "application/vnd.openxmlformats-officedocument.presentationml.presentation" in MIME_OVERRIDES
-
-    def test_mime_overrides_values(self):
-        """Test MIME_OVERRIDES maps to correct extensions.
-
-        Extensions are stored without a leading dot, matching the other
-        entries in the table and how ``detect_mime_type`` compares them
-        with ``str.endswith``.
-        """
-        assert MIME_OVERRIDES["application/vnd.openxmlformats-officedocument.wordprocessingml.document"] == "docx"
-        assert MIME_OVERRIDES["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"] == "xlsx"
-        assert MIME_OVERRIDES["application/vnd.openxmlformats-officedocument.presentationml.presentation"] == "pptx"
-        assert MIME_OVERRIDES["application/vnd.openxmlformats-officedocument.presentationml.slideshow"] == "ppsx"
 
 
 class TestReadConfig:

--- a/tests/unit/test_common_mime.py
+++ b/tests/unit/test_common_mime.py
@@ -70,7 +70,13 @@ class TestDetectMimeType:
     def test_extension_used_when_no_sniff(self):
         assert mime.detect_mime_type("report.pdf") == "application/pdf"
 
-    def test_mime_override_by_extension(self):
+    def test_mime_override_by_extension(self, monkeypatch):
+        # Force a guess_type miss so the MIME_OVERRIDES fallback runs on every
+        # platform. Linux CI ships /etc/mime.types (media-types) which knows
+        # .docx, so guess_type would otherwise return early and never reach
+        # the override loop; Windows lacks it. Patching keeps the branch
+        # deterministic regardless of the host mime database.
+        monkeypatch.setattr(mime.mimetypes, "guess_type", lambda *a, **k: (None, None))
         expected = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         assert mime.detect_mime_type("/x/report.docx") == expected
 

--- a/tests/unit/test_common_mime.py
+++ b/tests/unit/test_common_mime.py
@@ -1,0 +1,147 @@
+"""Tests for soliplex.agents.common.mime module."""
+
+import puremagic
+
+from soliplex.agents.common import mime
+
+# Minimal magic-byte payloads puremagic recognises deterministically.
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+
+
+class TestSniffBytes:
+    def test_empty_returns_none(self):
+        assert mime.sniff_bytes(b"") is None
+        assert mime.sniff_bytes(None) is None
+
+    def test_pdf_detected(self):
+        assert mime.sniff_bytes(PDF_BYTES) == "application/pdf"
+
+    def test_unidentifiable_text_returns_none(self):
+        # Plain text carries no magic signature -> PureError -> None.
+        assert mime.sniff_bytes(b"just some plain text, nothing magic") is None
+
+    def test_falsy_result_returns_none(self, monkeypatch):
+        # puremagic returning an empty string maps to None.
+        monkeypatch.setattr(puremagic, "from_string", lambda *a, **k: "")
+        assert mime.sniff_bytes(PDF_BYTES) is None
+
+
+class TestLooksLikeText:
+    def test_empty_is_not_text(self):
+        assert mime._looks_like_text(b"") is False
+        assert mime._looks_like_text(None) is False
+
+    def test_nul_byte_is_not_text(self):
+        assert mime._looks_like_text(b"hello\x00world") is False
+
+    def test_utf8_is_text(self):
+        assert mime._looks_like_text("héllo world".encode()) is True
+
+    def test_split_multibyte_at_boundary_is_text(self):
+        # Valid text followed by a truncated multi-byte char: trimming the
+        # trailing partial bytes should still decode.
+        data = b"hello" + "€".encode()[:2]  # euro sign, last byte dropped
+        assert mime._looks_like_text(data) is True
+
+    def test_undecodable_is_not_text(self):
+        assert mime._looks_like_text(b"\xff\xff\xff\xff") is False
+
+
+class TestDetectMimeType:
+    def test_header_wins_when_specific(self):
+        assert mime.detect_mime_type("a.bin", header_type="application/pdf", data=b"x") == "application/pdf"
+
+    def test_header_charset_normalized(self):
+        assert mime.detect_mime_type("a", header_type="Text/HTML; charset=utf-8") == "text/html"
+
+    def test_empty_header_ignored(self):
+        assert mime.detect_mime_type("notes.md", header_type="") == "text/markdown"
+
+    def test_whitespace_header_ignored(self):
+        assert mime.detect_mime_type("notes.md", header_type="   ") == "text/markdown"
+
+    def test_generic_header_ignored(self):
+        assert mime.detect_mime_type("notes.md", header_type="application/octet-stream") == "text/markdown"
+
+    def test_content_sniff(self):
+        assert mime.detect_mime_type("mystery", data=PNG_BYTES) == "image/png"
+
+    def test_extension_used_when_no_sniff(self):
+        assert mime.detect_mime_type("report.pdf") == "application/pdf"
+
+    def test_mime_override_by_extension(self):
+        expected = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        assert mime.detect_mime_type("/x/report.docx") == expected
+
+    def test_issues_default_markdown(self):
+        assert mime.detect_mime_type("/owner/repo/issues/12") == "text/markdown"
+
+    def test_text_fallback_for_extensionless_text(self):
+        assert mime.detect_mime_type("a", data=b"plain text here", text_fallback=True) == "text/plain"
+
+    def test_text_fallback_off_stays_octet_stream(self):
+        assert mime.detect_mime_type("a", data=b"plain text here") == "application/octet-stream"
+
+    def test_binary_extensionless_stays_octet_stream(self):
+        assert mime.detect_mime_type("a", data=b"\x00\x01\x02\x03", text_fallback=True) == "application/octet-stream"
+
+    def test_octet_stream_when_nothing_matches(self):
+        assert mime.detect_mime_type("a") == "application/octet-stream"
+
+
+class TestGuessExtension:
+    def test_none_returns_empty(self):
+        assert mime.guess_extension(None) == ""
+
+    def test_override_markdown(self):
+        assert mime.guess_extension("text/markdown") == ".md"
+
+    def test_standard_via_mimetypes(self):
+        assert mime.guess_extension("application/pdf") == ".pdf"
+
+    def test_unknown_returns_empty(self):
+        assert mime.guess_extension("application/x-madeup-type") == ""
+
+
+class TestEnsureExtension:
+    def test_no_extension_for_unknown_mime_kept(self):
+        assert mime.ensure_extension("data", "application/x-madeup-type") == "data"
+
+    def test_missing_extension_appended(self):
+        assert mime.ensure_extension("a", "application/pdf") == "a.pdf"
+
+    def test_correct_extension_kept(self):
+        assert mime.ensure_extension("a.pdf", "application/pdf") == "a.pdf"
+
+    def test_equivalent_extension_kept(self):
+        # .htm already resolves to text/html -> leave it alone.
+        assert mime.ensure_extension("a.htm", "text/html") == "a.htm"
+
+    def test_wrong_extension_replaced(self):
+        assert mime.ensure_extension("a.bin", "application/pdf") == "a.pdf"
+
+
+class TestExtensionAllowed:
+    def test_allowed(self):
+        assert mime.extension_allowed("application/pdf", ["md", "pdf"]) is True
+
+    def test_not_allowed(self):
+        assert mime.extension_allowed("application/octet-stream", ["md", "pdf"]) is False
+
+    def test_text_plain_allowed_when_txt_listed(self):
+        assert mime.extension_allowed("text/plain", ["md", "pdf", "txt"]) is True
+
+
+class TestPassesExtensionPrefilter:
+    def test_none_allowlist_passes_everything(self):
+        assert mime.passes_extension_prefilter("a.png", None) is True
+
+    def test_extensionless_passes(self):
+        assert mime.passes_extension_prefilter("/path/a", ["md", "pdf"]) is True
+
+    def test_allowed_extension_passes(self):
+        assert mime.passes_extension_prefilter("doc.pdf", ["md", "pdf"]) is True
+
+    def test_disallowed_extension_blocked(self):
+        assert mime.passes_extension_prefilter("image.png", ["md", "pdf"]) is False

--- a/tests/unit/test_common_urls_file.py
+++ b/tests/unit/test_common_urls_file.py
@@ -131,7 +131,7 @@ class TestReadTextFromWebdav:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.download.return_value = content
+        mock_client.download.return_value = (content, "text/plain")
         return patch(
             "soliplex.agents.webdav.async_client.create_async_webdav_client",
             return_value=mock_client,

--- a/tests/unit/test_local_store.py
+++ b/tests/unit/test_local_store.py
@@ -30,28 +30,22 @@ def test_sanitize_source_empty_fallback():
     assert local_store.sanitize_source(":::") == "source"
 
 
-# --- needs_extension ---
-
-
-@pytest.mark.parametrize(
-    "uri,expected",
-    [
-        ("https://example.com/page", True),
-        ("http://example.com/", True),
-        ("/owner/repo/issues/12", True),
-        ("docs/readme.md", False),
-        ("/abs/path/file.pdf", False),
-    ],
-)
-def test_needs_extension(uri, expected):
-    assert local_store.needs_extension(uri) is expected
-
-
 # --- uri_to_relpath ---
 
 
 def test_uri_to_relpath_plain_file():
     assert local_store.uri_to_relpath("docs/readme.md").as_posix() == "docs/readme.md"
+
+
+def test_uri_to_relpath_appends_extension_for_local_file():
+    # Extension is now reconciled for every source, not just URLs/issues.
+    rel = local_store.uri_to_relpath("docs/report", mime_type="application/pdf")
+    assert rel.as_posix() == "docs/report.pdf"
+
+
+def test_uri_to_relpath_replaces_wrong_extension():
+    rel = local_store.uri_to_relpath("docs/report.bin", mime_type="application/pdf")
+    assert rel.as_posix() == "docs/report.pdf"
 
 
 def test_uri_to_relpath_strips_leading_slash():

--- a/tests/unit/test_webdav_app.py
+++ b/tests/unit/test_webdav_app.py
@@ -30,7 +30,7 @@ def mock_webdav_client():
         {"name": "test.md", "type": "file", "size": 100, "etag": '"etag1"', "content_length": 100},
         {"name": "readme.pdf", "type": "file", "size": 200, "etag": '"etag2"', "content_length": 200},
     ]
-    client.download.return_value = b"test content"
+    client.download.return_value = (b"test content", "text/markdown")
     client.info.return_value = {"etag": '"etag_info"'}
     client.head.return_value = WebDAVResponse(status=200, headers={"etag": '"etag_head"'})
     client.__aenter__ = AsyncMock(return_value=client)
@@ -492,7 +492,7 @@ async def test_do_ingest_returns_sha256_on_success(local_env):
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
-    mock_client.download.return_value = b"file content"
+    mock_client.download.return_value = (b"file content", None)
     mock_client.head.return_value = WebDAVResponse(status=200, headers={})
 
     expected_sha = hashlib.sha256(b"file content", usedforsecurity=False).hexdigest()
@@ -567,7 +567,7 @@ async def test_load_inventory_from_urls_updates_state(tmp_path, local_env):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
     mock_client.info.return_value = {"etag": '"new_etag"'}
-    mock_client.download.return_value = b"downloaded"
+    mock_client.download.return_value = (b"downloaded", None)
     mock_client.head.return_value = WebDAVResponse(status=200, headers={})
 
     with patch("soliplex.agents.webdav.app.create_async_webdav_client", return_value=mock_client):

--- a/uv.lock
+++ b/uv.lock
@@ -3279,6 +3279,15 @@ wheels = [
 ]
 
 [[package]]
+name = "puremagic"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/74/ce5987ab9b8aec4ced06e2723ebb604205c9eb58abdad91453da93166380/puremagic-2.2.0.tar.gz", hash = "sha256:eb4bddf07c177c4b434554b92165b67449f5a51e152b976202d6254498810eef", size = 1189752, upload-time = "2026-04-08T01:39:55.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl", hash = "sha256:c4f7ed7307f056c787199acfda839555921be1df13abba61e8e6db0c787ae1d0", size = 71971, upload-time = "2026-04-08T01:39:54.169Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4347,6 +4356,7 @@ dependencies = [
     { name = "haiku-rag", extra = ["ingester"] },
     { name = "jinja2" },
     { name = "logfire", extra = ["fastapi"] },
+    { name = "puremagic" },
     { name = "pydantic-settings" },
     { name = "pypdfium2" },
     { name = "python-multipart" },
@@ -4380,6 +4390,7 @@ requires-dist = [
     { name = "haiku-rag", extras = ["ingester"], specifier = ">=0.55.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "logfire", extras = ["fastapi"] },
+    { name = "puremagic", specifier = ">=2.2.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pypdfium2", specifier = ">=4.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },


### PR DESCRIPTION
# Consolidate MIME / extension handling; content-based typing for extension-less files

## Summary

MIME-type detection and file-extension handling were scattered across the
four ingestion sources (`fs`, `scm`, `webdav`, `web`) and keyed off the
filename extension. As a result, **files with no extension were silently
skipped** before their bytes were ever read, extension logic was duplicated
in several modules, and one SCM filter used an unguarded
`name.split(".")[-1]` that misclassified extension-less files.

This PR centralizes all MIME/extension logic in a single module and switches
to **content-based** detection using [puremagic](https://pypi.org/project/puremagic/)
(pure-Python, no native `libmagic` dependency — works unchanged on Windows
dev and in the Linux container). Detection now follows a clear precedence,
downloaded files are named with the extension implied by their detected type,
and filtering happens against the **detected** type rather than the original
filename.

## Behavior

**Detection precedence** (`common/mime.py::detect_mime_type`):

1. Explicit `Content-Type` header (WebDAV: GET response / PROPFIND
   `getcontenttype`), unless generic (`application/octet-stream`).
2. Content sniffing via puremagic (magic bytes).
3. Filename extension (stdlib `mimetypes` + Office/text overrides + `/issues/`
   → `text/markdown`).
4. Plain-text default (**fs and git only**): extension-less, UTF-8-looking
   content → `text/plain`. WebDAV does **not** apply this — it relies on the
   server-provided type.
5. `application/octet-stream`.

**Extension naming** — the stored filename is reconciled against the detected
MIME type for every source: added when missing, replaced when it mismatches,
kept when already correct (no `report.pdf` → `report.pdf.pdf`).

**Detect-then-filter** — extension-less / unknown files are no longer dropped
up front. They are read/downloaded, classified by content, then filtered
against `EXTENSIONS` by their detected type. `text/plain` maps to the `txt`
allowlist entry, so add `txt` to `EXTENSIONS` to keep extension-less text
files.

### Net effect for `/my/path/a` (no extension)

| Source | Before | After |
|--------|--------|-------|
| fs (directory scan) | silently skipped | read, typed by content, written as e.g. `a.pdf` / `a.txt` |
| scm (files) | silently skipped | fetched, typed by content, named by type |
| webdav | skipped (`Extension . not allowed`) | typed from header, else sniffed; named by type |

## Changes by area

- **`common/mime.py`** (new, 100% covered): `detect_mime_type`,
  `sniff_bytes`, `_looks_like_text`, `guess_extension`, `ensure_extension`,
  `extension_allowed`, `passes_extension_prefilter`, and the `MIME_OVERRIDES`
  table.
- **`common/config.py`**: removed `detect_mime_type` / `MIME_OVERRIDES`
  (moved to `common/mime.py`); `read_config` / `check_config` unchanged.
- **`local_store.py`**: `uri_to_relpath` reconciles the extension for all
  sources via `ensure_extension`; dropped `_guess_ext`, `_EXT_OVERRIDES`, and
  the now-unused `needs_extension`.
- **SCM (`scm/base.py`, `scm/git_cli.py`, `scm/app.py`)**: type from content
  in `parse_file_rec` / `_read_local_file`; the git-CLI walker enumerates all
  files (was per-extension `rglob`, which couldn't see extension-less files);
  replaced the buggy `split(".")[-1]` filters with `extension_allowed`; and
  fixed `incremental_sync`'s removed-file delete to pass the stored
  `mime_type` so synthesized-extension paths round-trip.
- **WebDAV (`webdav/app.py`, `webdav/async_client.py`)**: `download()` now
  returns `(bytes, Content-Type)`; ingest resolves header → puremagic →
  extension; listing uses the PROPFIND content type and defers indeterminate
  types to download-time sniffing.
- **`common/urls_file.py`**: updated for the new `download()` return tuple.
- **`pyproject.toml` / `uv.lock`**: added `puremagic`.
- **`README.md`**: new "File Typing and Filtering" section plus updated
  feature/flow/architecture notes.
- **Incidental**: `manifest/haiku_loader.py` — subprocess stderr is now logged
  at `info` instead of `warning` (a small logging tweak carried in this
  commit, unrelated to the MIME work).

## Testing

- `uv run pytest tests/unit` — **897 passed, 100% branch coverage** (gate
  met). New `tests/unit/test_common_mime.py` covers the detection precedence,
  text-fallback, `sniff_bytes` error path, and extension helpers; existing
  `local_store`, `common_config`, `async_webdav_client`, `common_urls_file`,
  and `webdav_app` tests updated.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- End-to-end spot checks on the coverage-omitted `app.py` paths:
  - fs: extension-less PDF → written `a.pdf` (`application/pdf`);
    extension-less text → `notes.txt` (`text/plain`); a `.png` filtered out.
  - webdav: extension-less URL with GET `Content-Type: application/pdf` →
    `report.pdf`; no-header PNG content → sniffed `image/png`, skipped (not in
    allowlist).

## Notes / compatibility

- `puremagic` classifies binary formats by signature but cannot recognise
  plain text / Markdown; those still resolve via extension (or the fs/git
  `text/plain` default). Documented in the module docstring and README.
- No Dockerfile change required (puremagic is pure Python).


