### PR TITLE
Clean up deletion behavior and change to full sync with filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,13 +640,19 @@ When `delete_stale: true` is set in a manifest's `config` block, the runner remo
 
 **How it works:**
 
-1. All components execute sequentially, collecting every discovered URI and its hash
-2. After **all** components complete successfully, the consolidated URI set is compared against the local sync state for the source (all components in a manifest share one source, hence one download folder and state DB)
-3. Any document in local state whose URI is **not** in the consolidated set has its file, `.meta.json` sidecar, and state entry deleted.
+1. All components execute sequentially, collecting every discovered URI and its hash.
+2. After **all** components complete, the consolidated URI set is *reconciled against the actual download folder* for the source (all components in a manifest share one source, hence one download folder and state DB). Reconciliation is two-pass:
+   - **State pass:** any document tracked in local state whose URI is **not** in the consolidated set has its file, `.meta.json` sidecar, and state entry deleted.
+   - **Disk sweep:** the source download folder is then walked, and any file (plus its sidecar) that doesn't back a surviving URI is deleted — catching *orphans that were never tracked in state* (e.g. files left behind by an earlier run), not just files with a state row.
+
+**WebDAV 404 handling:**
+
+- A WebDAV file that returns **404 (Not Found)** during download is treated as a definitive removal, not a transient error. When `delete_stale` is on, its local copy is deleted (via the reconcile above) even if it still appears in a stale listing. A 404 does **not** block the reconcile.
+- This is distinct from *transient* errors (timeouts, 5xx) — see Safety below.
 
 **Safety:**
 
-- If **any** component produces an error (exception or unknown type), `delete_stale` is **skipped entirely** for that manifest run. This prevents accidental deletions when the URI set is incomplete due to a failed component.
+- If **any** component raises, hits an unknown type, or reports a **transient per-file error** (timeout / 5xx), `delete_stale` is **skipped entirely** for that manifest run. This prevents accidental deletions when the URI set may be incomplete. (A 404 is a removal signal, not a transient error, so it does not trigger this skip.)
 - Components that succeed still have their documents ingested normally — only the stale deletion step is skipped.
 
 **Example:**
@@ -667,7 +673,7 @@ components:
     path: /shared/docs
 ```
 
-If a file is removed from `/data/docs` or from the WebDAV server, the next manifest run will detect that its URI is no longer present and delete it from the download directory.
+If a file is removed from `/data/docs` or from the WebDAV server (dropped from the listing, or returning 404 on fetch), the next manifest run detects that its URI is no longer present and deletes it — and its sidecar — from the download directory.
 
 **Note:** SCM components using `incremental: true` only return files changed since the last sync, not the full file listing. When `delete_stale` is enabled with incremental SCM components, the stale detection may not have complete URI coverage for those components. Consider using full inventory mode (`incremental: false`) when `delete_stale` is needed with SCM sources.
 
@@ -787,7 +793,7 @@ invocation with `si-agent manifest run <path> --load` / `--no-load`.
 3. **Status Check**: The system checks which files are new or changed against the local sync state, so only new or changed files are processed
 4. **Write**: Each file is written to `<DOWNLOAD_DIR>/<source>/<source-relative-path>`, with a `<filename>.meta.json` sidecar containing its MIME type and other metadata. The stored filename is given the extension implied by its detected MIME type (added when missing, replaced when it mismatches, left alone when already correct) — see [File Typing and Filtering](#file-typing-and-filtering)
 5. **State Update**: Content hashes (and, for SCM, the latest commit SHA) are recorded in local state
-6. **Stale Removal** (optional): When `delete_stale` is enabled, documents no longer present in the source are deleted from the download directory
+6. **Stale Removal** (optional): When `delete_stale` is enabled, the download folder is reconciled against the source — documents no longer present (dropped from the listing, or 404 on fetch) are deleted, along with untracked orphan files (see [Stale Document Removal](#stale-document-removal))
 7. **haiku-rag Load** (optional): When `HAIKU_LOAD_ENABLED` is set, the downloaded documents are indexed into a per-source LanceDB database via `haiku-ingester` (see [haiku-rag Loading](#haiku-rag-loading))
 
 ### Incremental Sync (SCM Agent)

--- a/src/soliplex/agents/local_state.py
+++ b/src/soliplex/agents/local_state.py
@@ -146,6 +146,53 @@ def prune_documents(source: str, current_uris: set[str], download_dir: str | Non
     return removed
 
 
+def reconcile_documents(source: str, current_uris: set[str], download_dir: str | None = None) -> list[str]:
+    """Reconcile the on-disk download folder against *current_uris*.
+
+    Stricter than :func:`prune_documents`: in addition to dropping tracked
+    URIs that are no longer present, it sweeps the actual source download
+    folder and deletes any file that no longer backs a current URI --
+    catching orphans that have no state row (e.g. files left behind when a
+    document disappears from a WebDAV listing).
+
+    Args:
+        source: Source identifier.
+        current_uris: Set of URIs currently present in the source.
+        download_dir: Override for ``settings.download_dir``.
+
+    Returns:
+        List of removed identifiers (stale URIs and orphan relative paths).
+    """
+    state = load_file_state(source)
+
+    # (A) Tracked URIs no longer present: delete file, sidecar, and state row.
+    removed = [uri for uri in state if uri not in current_uris]
+    for uri in removed:
+        mime_type = state.get(uri, {}).get("mime_type")
+        local_store.delete_document(source, uri, mime_type=mime_type, download_dir=download_dir)
+    prune_files(source, current_uris)
+
+    # (B) Disk sweep: delete any file not backing a surviving URI. On-disk
+    # names use the resolved MIME type recorded in state, so recomputing the
+    # relative path from (uri, stored mime) reproduces the exact file written
+    # and cannot false-positive against a file we just stored.
+    expected: set[str] = set()
+    for uri, entry in state.items():
+        if uri in current_uris:
+            rel = local_store.uri_to_relpath(uri, mime_type=entry.get("mime_type")).as_posix()
+            expected.add(rel)
+            expected.add(rel + local_store.META_SUFFIX)
+
+    base = local_store.source_dir(source, download_dir)
+    if base.is_dir():
+        for path in base.rglob("*"):
+            if path.is_file() and path.relative_to(base).as_posix() not in expected:
+                path.unlink()
+                removed.append(path.relative_to(base).as_posix())
+
+    return removed
+
+
 def compute_to_process(inventory: list[dict], source: str) -> list[dict]:
     """Return inventory rows that are new or whose content changed.
 

--- a/src/soliplex/agents/manifest/cli.py
+++ b/src/soliplex/agents/manifest/cli.py
@@ -51,3 +51,8 @@ def run(
                     ingested = len(result.get("ingested", []))
                     errors = len(result.get("errors", []))
                     print(f"  {name}: {ingested} ingested, {errors} errors")
+            # Stale removal is reconciled once per manifest (over all
+            # components); report the count when delete_stale ran.
+            deleted = manifest_result.get("delete_stale_result")
+            if deleted is not None:
+                print(f"  deleted (stale): {len(deleted)}")

--- a/src/soliplex/agents/manifest/runner.py
+++ b/src/soliplex/agents/manifest/runner.py
@@ -325,6 +325,7 @@ async def run_manifest(manifest: Manifest) -> dict:
     logger.info("Starting manifest '%s' (%s) with %d components", manifest.id, manifest.name, len(manifest.components))
     results: list[dict[str, Any]] = []
     all_uri_hashes: list[dict[str, str]] = []
+    all_not_found: set[str] = set()
     has_errors = False
     incremental_scm_components: list[SCMComponent] = []
 
@@ -344,6 +345,13 @@ async def run_manifest(manifest: Manifest) -> dict:
                 incremental_scm_components.append(component)
             else:
                 all_uri_hashes.extend(collect_inventory_uris(result))
+            # 404s are removals, not errors: exclude them from the reconcile
+            # "should exist" set so their local copies are deleted.
+            all_not_found.update(result.get("not_found", []))
+            # Per-file transient errors (timeout/5xx) block the reconcile to
+            # stay safe, mirroring a raised component exception.
+            if result.get("errors"):
+                has_errors = True
             results.append({"component": component.name, "result": result})
             logger.info("Component '%s' completed successfully", component.name)
         except Exception as e:
@@ -366,15 +374,17 @@ async def run_manifest(manifest: Manifest) -> dict:
                 manifest.source,
             )
         else:
-            current_uris = {item["uri"] for item in all_uri_hashes}
-            delete_stale_result = local_state.prune_documents(manifest.source, current_uris)
+            current_uris = {item["uri"] for item in all_uri_hashes} - all_not_found
+            delete_stale_result = local_state.reconcile_documents(manifest.source, current_uris)
 
     error_count = sum(1 for r in results if "error" in r)
+    deleted_count = len(delete_stale_result or [])
     logger.info(
-        "Manifest '%s' finished: %d components, %d errors",
+        "Manifest '%s' finished: %d components, %d errors, %d deleted",
         manifest.id,
         len(results),
         error_count,
+        deleted_count,
     )
 
     return {

--- a/src/soliplex/agents/webdav/app.py
+++ b/src/soliplex/agents/webdav/app.py
@@ -569,7 +569,14 @@ async def load_inventory(
 
     ingested = []
     errors = []
-    ret = {"inventory": config, "to_process": to_process, "ingested": ingested, "errors": errors}
+    not_found = []
+    ret = {
+        "inventory": config,
+        "to_process": to_process,
+        "ingested": ingested,
+        "errors": errors,
+        "not_found": not_found,
+    }
     for idx, row in enumerate(to_process):
         uri = row["path"]
         try:
@@ -593,6 +600,11 @@ async def load_inventory(
             if "error" in res:
                 logger.error(f"Error writing {uri}: {res['error']}")
                 errors.append({"uri": uri, "error": res["error"]})
+            elif res.get("not_found"):
+                # Definitive removal, not a blocking error: excluded from the
+                # reconcile's "should exist" set below so its local copy is
+                # deleted (when delete_stale is on).
+                not_found.append(uri)
             elif res.get("skipped"):
                 logger.info("skipping %s: %s", uri, res["skipped"])
             else:
@@ -603,7 +615,8 @@ async def load_inventory(
 
     delete_stale_result = None
     if delete_stale and len(errors) == 0:
-        delete_stale_result = local_state.prune_documents(source, {r["path"] for r in config})
+        current = {r["path"] for r in config} - set(not_found)
+        delete_stale_result = local_state.reconcile_documents(source, current)
     ret["delete_stale_result"] = delete_stale_result
     return ret
 
@@ -655,6 +668,12 @@ async def do_ingest(
             logger.info(f"Downloading from WebDAV: {full_path}")
             async with webdav_client:
                 doc_body, header_type = await webdav_client.download(full_path)
+        except ResourceNotFound:
+            # 404 is a definitive "gone" signal (not a transient failure), so
+            # report it separately -- the caller treats it as a removal when
+            # delete_stale is enabled rather than a blocking error.
+            logger.info("source file gone (404): %s", uri)
+            return {"not_found": True, "uri": uri}
         except Exception as e:
             logger.exception(f"Error downloading {uri} from WebDAV")
             return {"error": str(e)}

--- a/tests/unit/test_local_state.py
+++ b/tests/unit/test_local_state.py
@@ -121,6 +121,61 @@ def test_prune_documents_deletes_files_and_state(state_env):
     assert set(local_state.load_file_state("s")) == {"a.md"}
 
 
+# --- reconcile_documents ---
+
+
+def test_reconcile_documents_removes_delisted(state_env):
+    # a.md (top level) and sub/c.md survive; b.md is delisted and removed.
+    local_store.write_document("s", "a.md", b"a", "text/markdown", {})
+    local_store.write_document("s", "sub/c.md", b"c", "text/markdown", {})
+    local_store.write_document("s", "b.md", b"b", "text/markdown", {})
+    for uri, sha in (("a.md", "1"), ("sub/c.md", "2"), ("b.md", "3")):
+        local_state.upsert_file("s", uri, sha, mime_type="text/markdown")
+
+    removed = local_state.reconcile_documents("s", {"a.md", "sub/c.md"})
+
+    assert removed == ["b.md"]
+    base = local_store.source_dir("s")
+    assert (base / "a.md").exists()
+    assert (base / "sub" / "c.md").exists()
+    assert not (base / "b.md").exists()
+    assert not (base / "b.md.meta.json").exists()
+    assert set(local_state.load_file_state("s")) == {"a.md", "sub/c.md"}
+
+
+def test_reconcile_documents_sweeps_disk_orphan(state_env):
+    # A file present on disk with no state row is swept even though the state
+    # comparison alone would never touch it.
+    local_store.write_document("s", "a.md", b"a", "text/markdown", {})
+    local_state.upsert_file("s", "a.md", "1", mime_type="text/markdown")
+    base = local_store.source_dir("s")
+    (base / "orphan.bin").write_bytes(b"x")
+
+    removed = local_state.reconcile_documents("s", {"a.md"})
+
+    assert removed == ["orphan.bin"]
+    assert (base / "a.md").exists()
+    assert (base / "a.md.meta.json").exists()
+    assert not (base / "orphan.bin").exists()
+
+
+def test_reconcile_documents_keeps_current(state_env):
+    local_store.write_document("s", "a.md", b"a", "text/markdown", {})
+    local_state.upsert_file("s", "a.md", "1", mime_type="text/markdown")
+
+    removed = local_state.reconcile_documents("s", {"a.md"})
+
+    assert removed == []
+    assert (local_store.source_dir("s") / "a.md").exists()
+
+
+def test_reconcile_documents_no_download_dir(state_env):
+    # No files ever written: the source folder doesn't exist, so the disk
+    # sweep is skipped and nothing is removed.
+    removed = local_state.reconcile_documents("s", set())
+    assert removed == []
+
+
 # --- sync meta ---
 
 

--- a/tests/unit/test_manifest_runner.py
+++ b/tests/unit/test_manifest_runner.py
@@ -792,17 +792,85 @@ class TestRunManifestDeleteStale:
 
         with (
             patch.dict(runner._DISPATCH, {FSComponent: mock_fs, WebComponent: mock_web}),
-            patch("soliplex.agents.manifest.runner.local_state.prune_documents") as mock_check,
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
         ):
             mock_check.return_value = []
             result = await runner.run_manifest(delete_stale_manifest)
 
-        # prune_documents called once with the source and consolidated URI set
+        # reconcile_documents called once with the source and consolidated URI set
         mock_check.assert_called_once()
         call_args = mock_check.call_args
         assert call_args[0][0] == "ds-src"
         assert call_args[0][1] == {"a.md", "http://example.com"}
         assert result["delete_stale_result"] == []
+
+    @pytest.mark.asyncio
+    async def test_not_found_excluded_from_reconcile_set(self, delete_stale_manifest):
+        # A 404'd URI is reported in not_found and must be subtracted from the
+        # reconcile "should exist" set so its local copy is removed.
+        fs_result = {
+            "inventory": [{"path": "a.md", "sha256": "h1"}, {"path": "b.md", "sha256": "h2"}],
+            "ingested": [],
+            "errors": [],
+            "not_found": ["b.md"],
+        }
+        web_result = {"inventory": [{"path": "http://example.com", "sha256": "h3"}], "ingested": [], "errors": []}
+
+        with (
+            patch.dict(
+                runner._DISPATCH,
+                {FSComponent: AsyncMock(return_value=fs_result), WebComponent: AsyncMock(return_value=web_result)},
+            ),
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
+        ):
+            mock_check.return_value = []
+            await runner.run_manifest(delete_stale_manifest)
+
+        mock_check.assert_called_once()
+        assert mock_check.call_args[0][1] == {"a.md", "http://example.com"}
+
+    @pytest.mark.asyncio
+    async def test_not_found_does_not_block_reconcile(self, delete_stale_manifest):
+        # A not_found entry (with no transient errors) must not block the reconcile.
+        fs_result = {"inventory": [{"path": "a.md", "sha256": "h1"}], "ingested": [], "errors": [], "not_found": ["b.md"]}
+        web_result = {"inventory": [], "ingested": [], "errors": []}
+
+        with (
+            patch.dict(
+                runner._DISPATCH,
+                {FSComponent: AsyncMock(return_value=fs_result), WebComponent: AsyncMock(return_value=web_result)},
+            ),
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
+        ):
+            mock_check.return_value = []
+            await runner.run_manifest(delete_stale_manifest)
+
+        mock_check.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_per_file_errors_block_reconcile(self, delete_stale_manifest, caplog):
+        # A transient per-file error (returned in a component's errors list, not
+        # raised) must block the reconcile to stay safe.
+        fs_result = {
+            "inventory": [{"path": "a.md", "sha256": "h1"}],
+            "ingested": [],
+            "errors": [{"uri": "a.md", "error": "HTTP 500"}],
+        }
+        web_result = {"inventory": [], "ingested": [], "errors": []}
+
+        with (
+            patch.dict(
+                runner._DISPATCH,
+                {FSComponent: AsyncMock(return_value=fs_result), WebComponent: AsyncMock(return_value=web_result)},
+            ),
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await runner.run_manifest(delete_stale_manifest)
+
+        mock_check.assert_not_called()
+        assert result["delete_stale_result"] is None
+        assert "Skipping delete_stale" in caplog.text
 
     @pytest.mark.asyncio
     async def test_delete_stale_skipped_on_component_error(self, delete_stale_manifest, caplog):
@@ -811,7 +879,7 @@ class TestRunManifestDeleteStale:
 
         with (
             patch.dict(runner._DISPATCH, {FSComponent: mock_fs, WebComponent: mock_web}),
-            patch("soliplex.agents.manifest.runner.local_state.prune_documents") as mock_check,
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
             caplog.at_level(logging.WARNING),
         ):
             result = await runner.run_manifest(delete_stale_manifest)
@@ -832,7 +900,7 @@ class TestRunManifestDeleteStale:
         m.components[0] = MagicMock(name="fake")
         m.components[0].name = "unknown"
 
-        with patch("soliplex.agents.manifest.runner.local_state.prune_documents") as mock_check:
+        with patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check:
             result = await runner.run_manifest(m)
 
         mock_check.assert_not_called()
@@ -850,7 +918,7 @@ class TestRunManifestDeleteStale:
 
         with (
             patch.dict(runner._DISPATCH, {FSComponent: mock_handler}),
-            patch("soliplex.agents.manifest.runner.local_state.prune_documents") as mock_check,
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
         ):
             result = await runner.run_manifest(m)
 
@@ -870,7 +938,7 @@ class TestRunManifestDeleteStale:
 
         with (
             patch.dict(runner._DISPATCH, {FSComponent: mock_handler}),
-            patch("soliplex.agents.manifest.runner.local_state.prune_documents") as mock_check,
+            patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
         ):
             result = await runner.run_manifest(m)
 
@@ -991,7 +1059,7 @@ class TestIncrementalSCMDeleteStale:
                 return_value=full_uris,
             ) as mock_list,
             patch(
-                "soliplex.agents.manifest.runner.local_state.prune_documents",
+                "soliplex.agents.manifest.runner.local_state.reconcile_documents",
                 return_value=[],
             ) as mock_check,
         ):
@@ -1060,7 +1128,7 @@ class TestIncrementalSCMDeleteStale:
                 new_callable=AsyncMock,
             ) as mock_list,
             patch(
-                "soliplex.agents.manifest.runner.local_state.prune_documents",
+                "soliplex.agents.manifest.runner.local_state.reconcile_documents",
             ) as mock_check,
         ):
             await runner.run_manifest(m)
@@ -1103,7 +1171,7 @@ class TestIncrementalSCMDeleteStale:
                 return_value=full_scm_uris,
             ),
             patch(
-                "soliplex.agents.manifest.runner.local_state.prune_documents",
+                "soliplex.agents.manifest.runner.local_state.reconcile_documents",
                 return_value=[],
             ) as mock_check,
         ):

--- a/tests/unit/test_webdav_app.py
+++ b/tests/unit/test_webdav_app.py
@@ -488,6 +488,58 @@ async def test_do_ingest_returns_error_on_download_failure(local_env):
 
 
 @pytest.mark.asyncio
+async def test_do_ingest_returns_not_found_on_404(local_env):
+    from soliplex.agents.webdav.async_client import ResourceNotFound
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.download.side_effect = ResourceNotFound("/webdav/docs/gone.md")
+
+    with patch("soliplex.agents.webdav.app.create_async_webdav_client", return_value=mock_client):
+        result = await webdav_app.do_ingest(
+            base_path="/webdav/docs",
+            uri="gone.md",
+            meta={},
+            source="test-source",
+            mime_type="text/markdown",
+            webdav_url="http://dav",
+        )
+
+    assert result == {"not_found": True, "uri": "gone.md"}
+    assert "error" not in result
+
+
+@pytest.mark.asyncio
+async def test_load_inventory_404_deletes_when_delete_stale(local_env):
+    # A previously-downloaded file that 404s on this run is removed from disk
+    # and state (via reconcile), and reported in not_found rather than errors.
+    source = "wd-src"
+    local_store.write_document(source, "gone.md", b"old", "text/markdown", {})
+    local_state.upsert_file(source, "gone.md", None, mime_type="text/markdown")
+    assert (local_store.source_dir(source) / "gone.md").exists()
+
+    from soliplex.agents.webdav.async_client import ResourceNotFound
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.download.side_effect = ResourceNotFound("/gone.md")
+    mock_client.head.return_value = WebDAVResponse(status=200, headers={})
+
+    # The listing still shows the file (race); sha256=None forces reprocessing.
+    config = [{"path": "gone.md", "sha256": None, "metadata": {"content-type": "text/markdown"}}]
+
+    with patch("soliplex.agents.webdav.app.create_async_webdav_client", return_value=mock_client):
+        result = await webdav_app.load_inventory("", source, config=config, webdav_url="http://dav", delete_stale=True)
+
+    assert result["not_found"] == ["gone.md"]
+    assert result["errors"] == []
+    assert not (local_store.source_dir(source) / "gone.md").exists()
+    assert "gone.md" not in local_state.load_file_state(source)
+
+
+@pytest.mark.asyncio
 async def test_do_ingest_returns_sha256_on_success(local_env):
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)


### PR DESCRIPTION
# WebDAV: delete on 404 and reconcile the download folder against the listing

## Summary

`delete_stale` removal was **state-DB-based** and driven only by *absence
from a successful listing*, which left two gaps:

1. **A 404 never deleted anything.** A WebDAV file that returned 404 on
   download was recorded as a generic error; that error blocked the stale
   prune and the previously-downloaded copy was kept.
2. **Disk orphans were never swept.** Pruning only removed files that still
   had a row in the per-source state DB, so a file left in the download
   folder but no longer in the listing (or never tracked) stayed behind.

This PR makes `delete_stale` reconcile the **actual download folder** against
the current listing and treat a **404 as a definitive removal**, and adds the
deletion count to the end-of-run manifest report.

Branches off `main` (which already contains the extension-cleanup work,
#67); this change builds on that base.

## Behavior

- **404 → delete (when `delete_stale`).** A WebDAV `ResourceNotFound` during
  download is reported as a removal (`not_found`), not a blocking error. Its
  URI is excluded from the reconcile "should exist" set, so its local copy is
  deleted even if it still appears in a stale listing. A 404 does **not**
  block the reconcile.
- **Download-folder reconcile.** After a manifest run (or a standalone WebDAV
  `load_inventory` with `delete_stale`), removal is two-pass:
  - **State pass** — tracked URIs no longer present are deleted (file +
    `.meta.json` sidecar + state row).
  - **Disk sweep** — the source folder is walked and any file not backing a
    surviving URI is deleted, catching untracked orphans.
- **Safety.** A raised component, an unknown component type, or a **transient
  per-file error** (timeout / 5xx) still skips `delete_stale` entirely for
  that run. A 404 is a removal signal, not a transient error, so it does not
  trigger the skip.

## Changes by area

- **`webdav/app.py`** — `do_ingest` returns `{"not_found": True, "uri": ...}`
  on `ResourceNotFound`; `load_inventory` collects `not_found` (kept out of
  `errors`), subtracts it from the reconcile set, and calls the new
  reconcile.
- **`local_state.py`** — new `reconcile_documents(source, current_uris,
  download_dir=None)`: state-based removals **plus** a disk sweep of
  `<DOWNLOAD_DIR>/<source>/`. Reuses `local_store.delete_document`,
  `source_dir`, `uri_to_relpath`, and `META_SUFFIX`. `prune_documents` stays
  for the fs/scm/web standalone paths.
- **`manifest/runner.py`** — unions component `not_found` (subtracted from the
  reconcile set), treats a component result's non-empty `errors` as blocking
  (not just raised exceptions), calls `reconcile_documents`, and logs
  `%d deleted` in the finish line.
- **`manifest/cli.py`** — the text report prints a manifest-level
  `deleted (stale): N` line when `delete_stale` ran.
- **`README.md`** — "Stale Document Removal" rewritten (two-pass reconcile +
  disk sweep), new "WebDAV 404 handling" subsection, and updated safety notes.

## Testing

- `uv run pytest tests/unit` — **906 passed, 100% branch coverage**
  (`local_state.py`, `manifest/runner.py` fully covered).
  - `test_local_state.py`: `reconcile_documents` — delisted tracked URI
    removed, disk orphan swept, surviving file kept, empty/no-folder cases.
  - `test_manifest_runner.py`: `not_found` subtracted from the reconcile set;
    a component `errors` list blocks the reconcile; a `not_found` entry does
    not.
  - `test_webdav_app.py`: `do_ingest` returns `not_found` on `ResourceNotFound`;
    `load_inventory` routes it to `not_found` and reconciles.
- `uv run ruff check` / `ruff format --check` — clean.
- End-to-end (live, mocked WebDAV client, real disk + state DB): a 404'd file
  still in the listing is deleted and reported in `not_found`; an untracked
  disk orphan is swept; a transient 500 blocks the reconcile (orphan left in
  place, `delete_stale_result=None`). Manifest text report shows
  `deleted (stale): N`.

## Notes

- The disk sweep deletes anything under `<DOWNLOAD_DIR>/<source>/` not backed
  by a surviving current URI. On-disk names are reproduced from the resolved
  MIME type recorded in state, so the sweep can't false-positive against a
  file it just wrote.
