### PR TITLE
add support for source_url in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,10 +791,41 @@ invocation with `si-agent manifest run <path> --load` / `--no-load`.
    - Filesystem/WebDAV/Web sources: SHA256 hash
    - SCM sources: SHA3-256 hash for files, SHA256 for issues
 3. **Status Check**: The system checks which files are new or changed against the local sync state, so only new or changed files are processed
-4. **Write**: Each file is written to `<DOWNLOAD_DIR>/<source>/<source-relative-path>`, with a `<filename>.meta.json` sidecar containing its MIME type and other metadata. The stored filename is given the extension implied by its detected MIME type (added when missing, replaced when it mismatches, left alone when already correct) — see [File Typing and Filtering](#file-typing-and-filtering)
+4. **Write**: Each file is written to `<DOWNLOAD_DIR>/<source>/<source-relative-path>`, with a `<filename>.meta.json` sidecar (see [Metadata Sidecars](#metadata-sidecars)). The stored filename is given the extension implied by its detected MIME type (added when missing, replaced when it mismatches, left alone when already correct) — see [File Typing and Filtering](#file-typing-and-filtering)
 5. **State Update**: Content hashes (and, for SCM, the latest commit SHA) are recorded in local state
 6. **Stale Removal** (optional): When `delete_stale` is enabled, the download folder is reconciled against the source — documents no longer present (dropped from the listing, or 404 on fetch) are deleted, along with untracked orphan files (see [Stale Document Removal](#stale-document-removal))
 7. **haiku-rag Load** (optional): When `HAIKU_LOAD_ENABLED` is set, the downloaded documents are indexed into a per-source LanceDB database via `haiku-ingester` (see [haiku-rag Loading](#haiku-rag-loading))
+
+### Metadata Sidecars
+
+Every downloaded document is accompanied by a `<filename>.meta.json` sidecar
+written next to it. The sidecar records:
+
+| Field | Description |
+| --- | --- |
+| `mime_type` | Detected MIME type (see [File Typing and Filtering](#file-typing-and-filtering)) |
+| `source` | Source identifier (the per-source folder name) |
+| `source_uri` | Source URI the document was discovered at |
+| `ingestion_type` | Method used to fetch the document: `fs`, `webdav`, `scm`, or `web` |
+| `sha256` | SHA256 of the written bytes |
+| `size` | Size of the written bytes |
+| `metadata` | Any additional source-specific metadata |
+| `source_url` | Full URL the document was downloaded from. Written for **WebDAV** downloads (omitted when a WebDAV source resolves to a local directory) and for **web** pages (the fetched page URL); omitted for `fs` and `scm` sources |
+
+Example sidecar for a WebDAV download:
+
+```json
+{
+  "mime_type": "text/markdown",
+  "source": "webdav:docs",
+  "source_uri": "handbook/readme.md",
+  "ingestion_type": "webdav",
+  "sha256": "…",
+  "size": 1234,
+  "metadata": {},
+  "source_url": "https://dav.example.com/docs/handbook/readme.md"
+}
+```
 
 ### Incremental Sync (SCM Agent)
 

--- a/src/soliplex/agents/fs/app.py
+++ b/src/soliplex/agents/fs/app.py
@@ -205,7 +205,7 @@ async def _write_local(
     # it from the bytes, defaulting extension-less text to text/plain.
     if not mime_type or mime_type == "application/octet-stream":
         mime_type = detect_mime_type(uri, data=doc_body, text_fallback=True)
-    local_store.write_document(source, uri, doc_body, mime_type, meta)
+    local_store.write_document(source, uri, doc_body, mime_type, meta, ingestion_type="fs")
     local_state.upsert_file(source, uri, sha256, size=len(doc_body), mime_type=mime_type)
 
 

--- a/src/soliplex/agents/local_store.py
+++ b/src/soliplex/agents/local_store.py
@@ -128,6 +128,8 @@ def write_document(
     mime_type: str | None,
     metadata: dict | None = None,
     *,
+    ingestion_type: str | None = None,
+    source_url: str | None = None,
     download_dir: str | None = None,
 ) -> Path:
     """Write *content* and its metadata sidecar to the download directory.
@@ -138,6 +140,10 @@ def write_document(
         content: Document bytes (str is encoded as UTF-8).
         mime_type: MIME type recorded in the sidecar and used for extensions.
         metadata: Additional metadata stored under the sidecar ``metadata`` key.
+        ingestion_type: Method used to fetch the document (e.g. ``"fs"``,
+            ``"webdav"``, ``"scm"``, ``"web"``), recorded in the sidecar.
+        source_url: Full URL the document was downloaded from, recorded in the
+            sidecar when available (currently WebDAV only).
         download_dir: Override for ``settings.download_dir`` (mainly for tests).
 
     Returns:
@@ -155,10 +161,13 @@ def write_document(
         "mime_type": mime_type,
         "source": source,
         "source_uri": uri,
+        "ingestion_type": ingestion_type,
         "sha256": hashlib.sha256(data, usedforsecurity=False).hexdigest(),
         "size": len(data),
         "metadata": metadata or {},
     }
+    if source_url is not None:
+        payload["source_url"] = source_url
     sidecar.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
     logger.info("wrote %s (%d bytes)", target, len(data))
     return target

--- a/src/soliplex/agents/scm/app.py
+++ b/src/soliplex/agents/scm/app.py
@@ -107,7 +107,7 @@ async def load_inventory(
             meta = _doc_meta(row, extra_metadata)
             doc_bytes = row["file_bytes"]
             logger.info(f"writing {uri}")
-            target = local_store.write_document(source, uri, doc_bytes, mime_type, meta)
+            target = local_store.write_document(source, uri, doc_bytes, mime_type, meta, ingestion_type="scm")
             processors.run_processors(target, mime_type)
             local_state.upsert_file(source, uri, row.get("sha256"), size=len(doc_bytes), mime_type=mime_type)
             ingested.append(uri)
@@ -421,7 +421,7 @@ async def incremental_sync(
             mime_type = _resolve_mime(file)
             meta = _doc_meta(file, extra_metadata)
             doc_bytes = file["file_bytes"]
-            target = local_store.write_document(source, uri, doc_bytes, mime_type, meta)
+            target = local_store.write_document(source, uri, doc_bytes, mime_type, meta, ingestion_type="scm")
             processors.run_processors(target, mime_type)
             local_state.upsert_file(source, uri, file.get("sha256"), size=len(doc_bytes), mime_type=mime_type)
             ingested.append(uri)

--- a/src/soliplex/agents/web/app.py
+++ b/src/soliplex/agents/web/app.py
@@ -138,7 +138,7 @@ async def load_inventory(
         if extra_metadata:
             meta.update(extra_metadata)
         try:
-            local_store.write_document(source, url, content_bytes, content_type, meta)
+            local_store.write_document(source, url, content_bytes, content_type, meta, ingestion_type="web", source_url=url)
             local_state.upsert_file(source, url, row.get("sha256"), size=len(content_bytes), mime_type=content_type)
             ingested.append(url)
         except Exception as e:

--- a/src/soliplex/agents/webdav/app.py
+++ b/src/soliplex/agents/webdav/app.py
@@ -655,6 +655,7 @@ async def do_ingest(
     logger.info(f"base_path={base_path}, uri={uri}")
 
     header_type = None
+    source_url = None
     # Check if base_path is a local directory
     if base_path and Path(base_path).exists():
         load_path = Path(base_path) / uri
@@ -665,6 +666,8 @@ async def do_ingest(
         try:
             webdav_client = create_async_webdav_client(webdav_url, webdav_username, webdav_password)
             full_path = f"{base_path.rstrip('/')}/{uri.lstrip('/')}" if base_path else uri
+            if webdav_url:
+                source_url = f"{webdav_url.rstrip('/')}/{full_path.lstrip('/')}"
             logger.info(f"Downloading from WebDAV: {full_path}")
             async with webdav_client:
                 doc_body, header_type = await webdav_client.download(full_path)
@@ -709,7 +712,7 @@ async def do_ingest(
         return {"skipped": reason, "uri": uri}
 
     sha256_hash = hashlib.sha256(doc_body, usedforsecurity=False).hexdigest()
-    local_store.write_document(source, uri, doc_body, mime_type, meta)
+    local_store.write_document(source, uri, doc_body, mime_type, meta, ingestion_type="webdav", source_url=source_url)
     if etag:
         logger.debug("recording %s in local state (validator=%s)", uri, etag)
     else:

--- a/tests/unit/test_fs_app.py
+++ b/tests/unit/test_fs_app.py
@@ -138,6 +138,9 @@ class TestLoadInventory:
         assert (sd / "test.md").read_text() == "# Test Document\n\nThis is a test."
         assert (sd / "test.md.meta.json").exists()
         assert (sd / "readme.md").exists()
+        meta = json.loads((sd / "test.md.meta.json").read_text())
+        assert meta["ingestion_type"] == "fs"
+        assert "source_url" not in meta
 
     @pytest.mark.asyncio
     async def test_load_inventory_skips_unchanged(self, temp_document_dir, local_env):

--- a/tests/unit/test_local_store.py
+++ b/tests/unit/test_local_store.py
@@ -122,6 +122,25 @@ def test_write_document_writes_file_and_sidecar(dl):
     assert meta["size"] == 5
     assert meta["sha256"]
     assert meta["metadata"] == {"last_commit_sha": "abc"}
+    # ingestion_type defaults to None; source_url is omitted unless provided.
+    assert meta["ingestion_type"] is None
+    assert "source_url" not in meta
+
+
+def test_write_document_records_ingestion_type_and_source_url(dl):
+    target = local_store.write_document(
+        "webdav:host",
+        "docs/readme.md",
+        b"hello",
+        "text/markdown",
+        {},
+        ingestion_type="webdav",
+        source_url="https://dav.example.com/docs/readme.md",
+    )
+    sidecar = target.with_name(target.name + ".meta.json")
+    meta = json.loads(sidecar.read_text())
+    assert meta["ingestion_type"] == "webdav"
+    assert meta["source_url"] == "https://dav.example.com/docs/readme.md"
 
 
 def test_write_document_accepts_str(dl):

--- a/tests/unit/test_webdav_app.py
+++ b/tests/unit/test_webdav_app.py
@@ -1,6 +1,7 @@
 """Tests for soliplex.agents.webdav.app module."""
 
 import hashlib
+import json
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -562,8 +563,13 @@ async def test_do_ingest_returns_sha256_on_success(local_env):
     assert result["_sha256"] == expected_sha
     assert result["_size"] == len(b"file content")
     # file written under the source folder and state updated
-    assert (local_store.source_dir("test-source") / "test.md").read_bytes() == b"file content"
+    target = local_store.source_dir("test-source") / "test.md"
+    assert target.read_bytes() == b"file content"
     assert local_state.load_file_state("test-source")["test.md"]["sha256"] == expected_sha
+    # the sidecar records the webdav ingestion type and the full download URL
+    sidecar = json.loads((target.parent / "test.md.meta.json").read_text())
+    assert sidecar["ingestion_type"] == "webdav"
+    assert sidecar["source_url"] == "http://dav/webdav/docs/test.md"
 
 
 @pytest.mark.asyncio
@@ -582,6 +588,11 @@ async def test_do_ingest_local_file_returns_sha256(tmp_path, local_env):
 
     assert result["_sha256"] == expected_sha
     assert result["_size"] == len(b"local content")
+    # a local-directory read has no download URL, so source_url is omitted
+    target = local_store.source_dir("test-source") / "test.md"
+    sidecar = json.loads((target.parent / "test.md.meta.json").read_text())
+    assert sidecar["ingestion_type"] == "webdav"
+    assert "source_url" not in sidecar
 
 
 # --- load_inventory_from_urls ---


### PR DESCRIPTION
# Sidecars: record `ingestion_type` (and `source_url` for network fetches)

## Summary

Every `.meta.json` sidecar now records **how** the document was fetched, and
network-fetched documents record the **full URL** they came from. Two new
top-level sidecar fields:

- **`ingestion_type`** — the method used to download the document: `fs`,
  `webdav`, `scm`, or `web`. Written on **every** sidecar.
- **`source_url`** — the full URL the document was downloaded from. Written
  for **WebDAV** downloads and **web** pages; **omitted** for `fs`/`scm`
  sources and for WebDAV sources that resolve to a local directory (no network
  fetch).

Previously a sidecar recorded `source` and `source_uri` but nothing about the
retrieval method, and the absolute WebDAV URL was discarded after download.

## Behavior

- **`ingestion_type` on every sidecar.** Each agent tags its writes with its
  own method string, so downstream consumers can tell a filesystem copy from a
  WebDAV/web/SCM fetch without re-deriving it from the source identifier.
- **`source_url` only when there is a URL.**
  - **WebDAV** — the absolute GET URL is reconstructed from the server base URL
    plus the resolved path (`<webdav_url>/<base_path>/<uri>`). When a WebDAV
    source is actually a local directory mount, there is no download URL, so
    the field is omitted.
  - **Web** — the fetched page URL (identical to `source_uri` for this agent).
  - **fs / scm** — no network URL, so the field is absent (not `null`).

## Example (WebDAV download)

```json
{
  "mime_type": "text/markdown",
  "source": "webdav:docs",
  "source_uri": "handbook/readme.md",
  "ingestion_type": "webdav",
  "sha256": "…",
  "size": 1234,
  "metadata": {},
  "source_url": "https://dav.example.com/docs/handbook/readme.md"
}
```

## Changes by area

- **`local_store.py`** — `write_document` gains two keyword-only args,
  `ingestion_type` and `source_url`. `ingestion_type` is always written;
  `source_url` is added to the payload only when non-`None`, so unaffected
  sources stay clean.
- **`webdav/app.py`** — `do_ingest` reconstructs `source_url` from
  `webdav_url` + the resolved `full_path` in the download branch (left `None`
  for the local-directory branch) and passes `ingestion_type="webdav"`.
- **`web/app.py`** — passes `ingestion_type="web"` and `source_url=<page url>`.
- **`fs/app.py`** — passes `ingestion_type="fs"`.
- **`scm/app.py`** — passes `ingestion_type="scm"` at both the full-load and
  incremental-sync write sites.
- **`README.md`** — new "Metadata Sidecars" section with a field table
  (including the two new fields) and a worked WebDAV example; the ingestion-flow
  "Write" step links to it.

## Testing

- `uv run pytest tests/unit` — **907 passed, 100% branch coverage.**
  - `test_local_store.py`: `write_document` defaults (`ingestion_type` is
    `None`, `source_url` omitted); a webdav-style call records both fields.
  - `test_webdav_app.py`: a network download records `ingestion_type="webdav"`
    and the reconstructed `source_url`; a local-directory read records the type
    but omits `source_url`.
  - `test_fs_app.py`: filesystem writes record `ingestion_type="fs"` and omit
    `source_url`.
- `uv run ruff check` / `uv run ruff format --check` — clean.

## Notes

- The agent `app.py` modules (`fs`, `webdav`, `scm`, `web`) are in the coverage
  `omit` list (`pyproject.toml`), so the per-agent call-site wiring is not
  coverage-tracked; the new field logic that *is* tracked lives in
  `local_store.py` and is fully covered. The web write path therefore has no
  direct sidecar-content assertion — a `test_web_app.py` exercising
  `load_inventory` for real could be added if we want that guarded too.
- `source_url` is intentionally omitted (rather than set to `null`) for sources
  without a network URL, keeping existing `fs`/`scm` sidecars byte-compatible
  aside from the added `ingestion_type` key.
