### PR TITLE
add post-processing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Top-level fields:
   - **extensions**: File extensions to include (overrides the global `EXTENSIONS` setting).
   - **delete_stale**: Remove locally-stored documents that no longer appear in any component (default: false). See [Stale Document Removal](#stale-document-removal) below.
   - **haiku_config**: Override the haiku-rag config file used when loading this manifest's source. Absolute paths are used as-is; relative values resolve under `HAIKU_PATH`. Defaults to `${HAIKU_PATH}/haiku.rag.default.yaml`. See [haiku-rag Loading](#haiku-rag-loading).
+  - **post_process**: Ordered callbacks run after the haiku-rag load completes. See [Post-process callbacks](#post-process-callbacks) below.
 - **components** (required): List of ingestion components (see below).
 
 #### Component Types
@@ -777,6 +778,42 @@ si-agent serve
 
 The CLI honors the same `HAIKU_LOAD_ENABLED` default; override per
 invocation with `si-agent manifest run <path> --load` / `--no-load`.
+
+#### Post-process callbacks
+
+A manifest's `config.post_process` is an ordered list of callbacks invoked
+**after** the haiku-rag load for that source completes successfully (and after
+its summary has been streamed). Each entry names a `method` (a dotted import
+path) and optional `kwargs`; the callback is invoked as
+`method(source, **kwargs)` — `source` is the manifest's source and `kwargs`
+are the configured extra args.
+
+```yaml
+config:
+  haiku_config: haiku.rag.custom.yaml
+  post_process:
+    - method: soliplex.agents.manifest.post_processors:vacuum
+      kwargs: { vacuum_retention_seconds: 0 }
+    - method: your_project.postprocess:identify_and_apply
+      kwargs: { only_missing: true, overrides: /etc/agent/overrides.json }
+```
+
+- **Dotted path:** `pkg.mod:func` or `pkg.mod.func`. The module must be
+  importable in the agent's environment.
+- **Ordering:** steps run sequentially in the order listed.
+- **Config auto-inject:** when a step omits `config` and the callable accepts
+  one (an explicit `config` parameter or `**kwargs`), the manifest's resolved
+  haiku config path is passed so the callback opens the store with the same
+  config the load used.
+- **Failure isolation:** a step that raises is logged and recorded; the
+  remaining steps still run. The per-step outcomes are returned under the load
+  result's `post_process` key.
+- **Only after a successful load:** post-process does not run when the load
+  fails, times out, or is skipped (`--no-load`).
+
+Built-in callback: `soliplex.agents.manifest.post_processors:vacuum` runs
+LanceDB maintenance (optimize + clean up table history) on the per-source
+database.
 
 **Note:** All commands support WebDAV credentials via environment variables (`WEBDAV_URL`, `WEBDAV_USERNAME`, `WEBDAV_PASSWORD`) or command-line options (`--webdav-url`, `--webdav-username`, `--webdav-password`).
 

--- a/src/soliplex/agents/config.py
+++ b/src/soliplex/agents/config.py
@@ -8,6 +8,7 @@ from datetime import UTC
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
+from typing import Any
 from typing import Literal
 
 from pydantic import BaseModel
@@ -378,6 +379,18 @@ Component = Annotated[
 # --- Manifest Config ---
 
 
+class PostProcessStep(BaseModel):
+    """One post-load callback, invoked as ``method(source, **kwargs)``.
+
+    ``method`` is a dotted import path (``pkg.mod:func`` or ``pkg.mod.func``);
+    ``kwargs`` are passed through as keyword arguments. See
+    ``docs/post-process-plan.md``.
+    """
+
+    method: str
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 class ManifestConfig(BaseModel):
     """Shared configuration applied to all components in a manifest."""
 
@@ -385,6 +398,9 @@ class ManifestConfig(BaseModel):
     metadata: dict[str, str] | None = None
     delete_stale: bool = True
     haiku_config: str | None = None  # Per-manifest haiku-rag config (abs path, or filename under HAIKU_PATH)
+    # Ordered callbacks run after the haiku-rag load completes (see
+    # soliplex.agents.manifest.post_process).
+    post_process: list[PostProcessStep] = Field(default_factory=list)
 
 
 class Schedule(BaseModel):

--- a/src/soliplex/agents/manifest/haiku_loader.py
+++ b/src/soliplex/agents/manifest/haiku_loader.py
@@ -217,6 +217,14 @@ async def run_load(manifest: Manifest) -> dict:
             source,
             proc.returncode,
         )
+    post_process_results: list[dict] = []
+    if proc.returncode == 0 and manifest.config and manifest.config.post_process:
+        # Local import avoids a circular import (post_process imports
+        # resolve_haiku_cfg from this module).
+        from soliplex.agents.manifest import post_process
+
+        post_process_results = await post_process.run_post_process(manifest)
+
     return {
         "source": source,
         "db": db,
@@ -224,4 +232,5 @@ async def run_load(manifest: Manifest) -> dict:
         "stdout": out,
         "stderr": err,
         "timed_out": False,
+        "post_process": post_process_results,
     }

--- a/src/soliplex/agents/manifest/post_process.py
+++ b/src/soliplex/agents/manifest/post_process.py
@@ -1,0 +1,92 @@
+"""Invoke a manifest's ``config.post_process`` callbacks after a load.
+
+Each step names a dotted-path callable (``pkg.mod:func`` or ``pkg.mod.func``)
+that is invoked as ``method(source, **kwargs)`` -- ``source`` is the manifest's
+source, ``kwargs`` are the configured extra args. Steps run **in order** after
+``haiku-ingester`` finishes (see :func:`haiku_loader.run_load`).
+
+Two conveniences:
+
+* **config auto-inject** -- when a step omits ``config`` and the callable
+  accepts one (an explicit ``config`` parameter or ``**kwargs``), the manifest's
+  resolved haiku config path is passed so the callback opens the store with the
+  same config the load used;
+* **log-and-continue** -- a failing step is logged and recorded, and the
+  remaining steps still run.
+
+See ``docs/post-process-plan.md``.
+"""
+
+import importlib
+import inspect
+import logging
+from collections.abc import Callable
+from inspect import Parameter
+
+from soliplex.agents.config import Manifest
+from soliplex.agents.manifest.haiku_loader import resolve_haiku_cfg
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_method(spec: str) -> Callable:
+    """Import a dotted-path callable.
+
+    Accepts ``"pkg.mod:func"`` (module / attribute split on ``:``) and, as a
+    fallback, ``"pkg.mod.func"`` (split on the last ``.``).
+    """
+    module_name, sep, attr = spec.partition(":")
+    if not sep:
+        module_name, _, attr = spec.rpartition(".")
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)
+
+
+def _wants_config(method: Callable) -> bool:
+    """Whether ``method`` accepts a ``config`` keyword (named or via ``**kwargs``)."""
+    try:
+        params = inspect.signature(method).parameters
+    except (TypeError, ValueError):  # pragma: no cover - builtins without signatures
+        return False
+    if "config" in params:
+        return True
+    return any(p.kind is Parameter.VAR_KEYWORD for p in params.values())
+
+
+async def run_post_process(manifest: Manifest) -> list[dict]:
+    """Run ``manifest.config.post_process`` callbacks in order.
+
+    Returns a per-step outcome list of ``{"method", "ok", "error"}`` dicts. A
+    step that raises is logged and recorded with ``ok=False``; execution
+    continues with the next step.
+    """
+    if manifest.config is None or not manifest.config.post_process:
+        return []
+
+    results: list[dict] = []
+    for step in manifest.config.post_process:
+        outcome: dict = {"method": step.method, "ok": True, "error": None}
+        try:
+            method = _resolve_method(step.method)
+            kwargs = dict(step.kwargs)
+            if "config" not in kwargs and _wants_config(method):
+                kwargs["config"] = resolve_haiku_cfg(manifest)
+            logger.info(
+                "Running post-process '%s' for source '%s'",
+                step.method,
+                manifest.source,
+            )
+            value = method(manifest.source, **kwargs)
+            if inspect.isawaitable(value):
+                await value
+            logger.info("Post-process '%s' completed", step.method)
+        except Exception as exc:
+            logger.exception(
+                "Post-process '%s' failed for source '%s'",
+                step.method,
+                manifest.source,
+            )
+            outcome["ok"] = False
+            outcome["error"] = str(exc)
+        results.append(outcome)
+    return results

--- a/src/soliplex/agents/manifest/post_processors.py
+++ b/src/soliplex/agents/manifest/post_processors.py
@@ -1,0 +1,57 @@
+"""Built-in manifest post-process callbacks.
+
+A post-process callback is referenced from a manifest's ``config.post_process``
+list by dotted path and invoked as ``method(source, **kwargs)`` after the
+``haiku-ingester`` load for that source completes (see
+``docs/post-process-plan.md``). This module holds the callbacks that ship with
+ingester-agents.
+"""
+
+import logging
+from pathlib import Path
+
+from haiku.rag.app import HaikuRAGApp
+from haiku.rag.config import AppConfig
+from haiku.rag.config import get_config
+from haiku.rag.config import load_yaml_config
+
+from soliplex.agents.manifest.haiku_loader import resolve_db_path
+
+logger = logging.getLogger(__name__)
+
+
+def _load_app_config(config: str | None) -> AppConfig:
+    """Load an ``AppConfig`` from a path, or haiku's own config discovery."""
+    if config:
+        return AppConfig.model_validate(load_yaml_config(config))
+    return get_config()
+
+
+async def vacuum(
+    source: str,
+    *,
+    config: str | None = None,
+    vacuum_retention_seconds: int | None = 0,
+) -> None:
+    """Vacuum the per-source LanceDB (optimize + clean up table history).
+
+    A post-process callback: resolves the same ``${LANCEDB_DIR}/<slug>.lancedb``
+    the load wrote (via :func:`resolve_db_path`), opens a
+    :class:`~haiku.rag.app.HaikuRAGApp`, and runs its ``vacuum``.
+
+    Args:
+        source: The manifest source; slugified to locate the database.
+        config: Optional haiku.rag config path. When omitted, the manifest's
+            resolved config is auto-injected by the post-process runner (or
+            haiku's own discovery is used). It must match the DB embedder.
+        vacuum_retention_seconds: Overrides the config's retention window before
+            vacuuming. Defaults to ``0`` -- reclaim everything
+    """
+    db_path = Path(resolve_db_path(source))
+    app_config = _load_app_config(config)
+    if vacuum_retention_seconds is not None:
+        app_config.storage.vacuum_retention_seconds = vacuum_retention_seconds
+    logger.info("Vacuuming LanceDB for source '%s' -> %s", source, db_path)
+    app = HaikuRAGApp(db_path=db_path, config=app_config)
+    await app.vacuum()
+    logger.info("Vacuum completed for source '%s'", source)

--- a/tests/unit/test_haiku_loader.py
+++ b/tests/unit/test_haiku_loader.py
@@ -10,6 +10,7 @@ from pydantic import SecretStr
 
 from soliplex.agents.config import Manifest
 from soliplex.agents.config import ManifestConfig
+from soliplex.agents.config import PostProcessStep
 from soliplex.agents.config import settings
 from soliplex.agents.manifest import haiku_loader
 
@@ -251,3 +252,54 @@ class TestRunLoad:
         proc.wait.assert_awaited_once()
         assert result["timed_out"] is True
         assert result["returncode"] is None
+
+    @pytest.mark.asyncio
+    async def test_post_process_runs_on_success(self, haiku_env):
+        manifest = Manifest(
+            id="m",
+            name="M",
+            source="src",
+            config=ManifestConfig(post_process=[PostProcessStep(method="pkg:fn")]),
+            components=[{"type": "fs", "name": "c", "path": "/data"}],
+        )
+        proc = _fake_proc(returncode=0)
+        with (
+            patch(
+                "soliplex.agents.manifest.haiku_loader.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ),
+            patch(
+                "soliplex.agents.manifest.post_process.run_post_process",
+                new_callable=AsyncMock,
+                return_value=[{"method": "pkg:fn", "ok": True, "error": None}],
+            ) as mock_pp,
+        ):
+            result = await haiku_loader.run_load(manifest)
+        mock_pp.assert_awaited_once_with(manifest)
+        assert result["post_process"] == [{"method": "pkg:fn", "ok": True, "error": None}]
+
+    @pytest.mark.asyncio
+    async def test_post_process_skipped_on_nonzero(self, haiku_env):
+        manifest = Manifest(
+            id="m",
+            name="M",
+            source="src",
+            config=ManifestConfig(post_process=[PostProcessStep(method="pkg:fn")]),
+            components=[{"type": "fs", "name": "c", "path": "/data"}],
+        )
+        proc = _fake_proc(returncode=1, stdout_lines=[], stderr_lines=[b"x\n"])
+        with (
+            patch(
+                "soliplex.agents.manifest.haiku_loader.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ),
+            patch(
+                "soliplex.agents.manifest.post_process.run_post_process",
+                new_callable=AsyncMock,
+            ) as mock_pp,
+        ):
+            result = await haiku_loader.run_load(manifest)
+        mock_pp.assert_not_awaited()
+        assert result["post_process"] == []

--- a/tests/unit/test_manifest_models.py
+++ b/tests/unit/test_manifest_models.py
@@ -201,10 +201,22 @@ class TestManifestConfig:
         c = ManifestConfig()
         assert c.delete_stale is True
         assert c.haiku_config is None
+        assert c.post_process == []
 
     def test_haiku_config_override(self):
         c = ManifestConfig(haiku_config="custom.yaml")
         assert c.haiku_config == "custom.yaml"
+
+    def test_post_process_steps(self):
+        c = ManifestConfig(
+            post_process=[
+                {"method": "pkg.mod:fn", "kwargs": {"x": 1}},
+                {"method": "pkg.mod:other"},  # kwargs defaults to {}
+            ]
+        )
+        assert [s.method for s in c.post_process] == ["pkg.mod:fn", "pkg.mod:other"]
+        assert c.post_process[0].kwargs == {"x": 1}
+        assert c.post_process[1].kwargs == {}
 
 
 # --- Schedule ---

--- a/tests/unit/test_post_process.py
+++ b/tests/unit/test_post_process.py
@@ -1,0 +1,124 @@
+"""Tests for the manifest post-process runner — 100% branch coverage required."""
+
+import os
+
+import pytest
+
+from soliplex.agents.config import Manifest
+from soliplex.agents.config import ManifestConfig
+from soliplex.agents.config import PostProcessStep
+from soliplex.agents.manifest import post_process
+
+
+def _manifest(steps=None, *, with_config=True, source="src"):
+    config = ManifestConfig(post_process=steps or []) if with_config else None
+    return Manifest(
+        id="m",
+        name="M",
+        source=source,
+        config=config,
+        components=[{"type": "fs", "name": "c", "path": "/data"}],
+    )
+
+
+# --- _resolve_method ---
+
+
+def test_resolve_method_colon():
+    assert post_process._resolve_method("os:getcwd") is os.getcwd
+
+
+def test_resolve_method_dotted():
+    assert post_process._resolve_method("os.getcwd") is os.getcwd
+
+
+# --- _wants_config ---
+
+
+def test_wants_config_named_param():
+    def method(source, *, config=None): ...
+
+    assert post_process._wants_config(method) is True
+
+
+def test_wants_config_var_keyword():
+    def method(source, **kwargs): ...
+
+    assert post_process._wants_config(method) is True
+
+
+def test_wants_config_absent():
+    def method(source, *, x=1): ...
+
+    assert post_process._wants_config(method) is False
+
+
+# --- run_post_process ---
+
+
+@pytest.mark.asyncio
+async def test_no_config_returns_empty():
+    assert await post_process.run_post_process(_manifest(with_config=False)) == []
+
+
+@pytest.mark.asyncio
+async def test_empty_steps_returns_empty():
+    assert await post_process.run_post_process(_manifest(steps=[])) == []
+
+
+@pytest.mark.asyncio
+async def test_runs_in_order_with_inject_and_sync_async(monkeypatch):
+    calls: list[tuple] = []
+
+    async def async_cb(source, **kwargs):  # **kwargs -> wants config
+        calls.append(("async", source, kwargs))
+
+    def sync_cb(source, *, config=None, x=None):  # named config -> wants config
+        calls.append(("sync", source, {"config": config, "x": x}))
+
+    def no_config_cb(source, *, y=None):  # no config param -> no inject
+        calls.append(("noconf", source, {"y": y}))
+
+    registry = {"a": async_cb, "s": sync_cb, "n": no_config_cb}
+    monkeypatch.setattr(post_process, "_resolve_method", lambda spec: registry[spec])
+    monkeypatch.setattr(post_process, "resolve_haiku_cfg", lambda manifest: "CFG")
+
+    steps = [
+        PostProcessStep(method="a"),  # inject CFG (via **kwargs), awaited
+        PostProcessStep(method="s", kwargs={"x": 1}),  # inject CFG (named), sync
+        PostProcessStep(method="s", kwargs={"config": "OWN", "x": 2}),  # no inject
+        PostProcessStep(method="n"),  # no inject (method rejects config)
+    ]
+    results = await post_process.run_post_process(_manifest(steps=steps, source="s1"))
+
+    assert [r["ok"] for r in results] == [True, True, True, True]
+    assert all(r["error"] is None for r in results)
+    assert calls == [
+        ("async", "s1", {"config": "CFG"}),
+        ("sync", "s1", {"config": "CFG", "x": 1}),
+        ("sync", "s1", {"config": "OWN", "x": 2}),
+        ("noconf", "s1", {"y": None}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failing_step_is_logged_and_others_continue(monkeypatch):
+    ran: list[str] = []
+
+    def boom(source, **kwargs):
+        raise RuntimeError("nope")
+
+    def ok(source, **kwargs):
+        ran.append(source)
+
+    registry = {"boom": boom, "ok": ok}
+    monkeypatch.setattr(post_process, "_resolve_method", lambda spec: registry[spec])
+    monkeypatch.setattr(post_process, "resolve_haiku_cfg", lambda manifest: "CFG")
+
+    steps = [PostProcessStep(method="boom"), PostProcessStep(method="ok")]
+    results = await post_process.run_post_process(_manifest(steps=steps))
+
+    assert results[0]["ok"] is False
+    assert "nope" in results[0]["error"]
+    assert results[1]["ok"] is True
+    assert ran == ["src"]  # the step after the failure still ran

--- a/tests/unit/test_post_processors.py
+++ b/tests/unit/test_post_processors.py
@@ -1,0 +1,113 @@
+"""Tests for built-in manifest post-process callbacks — 100% branch coverage."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from soliplex.agents.config import settings
+from soliplex.agents.manifest import post_processors
+
+
+@pytest.fixture
+def lancedb_env(monkeypatch):
+    """Point the per-source DB resolver at a known base dir."""
+    monkeypatch.setattr(settings, "lancedb_dir", "/data/lance", raising=False)
+
+
+# --- _load_app_config -----------------------------------------------------
+
+
+def test_load_app_config_from_path():
+    with (
+        patch.object(post_processors, "load_yaml_config", return_value={"k": "v"}) as load_yaml,
+        patch.object(post_processors.AppConfig, "model_validate", return_value="CFG") as validate,
+    ):
+        result = post_processors._load_app_config("cfg.yaml")
+
+    load_yaml.assert_called_once_with("cfg.yaml")
+    validate.assert_called_once_with({"k": "v"})
+    assert result == "CFG"
+
+
+def test_load_app_config_from_discovery():
+    with patch.object(post_processors, "get_config", return_value="DISCOVERED") as get_cfg:
+        result = post_processors._load_app_config(None)
+
+    get_cfg.assert_called_once_with()
+    assert result == "DISCOVERED"
+
+
+# --- vacuum ---------------------------------------------------------------
+
+
+def _fake_config(retention=999):
+    return SimpleNamespace(storage=SimpleNamespace(vacuum_retention_seconds=retention))
+
+
+@pytest.mark.asyncio
+async def test_vacuum_resolves_db_forces_full_reclaim_and_runs(lancedb_env):
+    cfg = _fake_config()
+    app = MagicMock()
+    app.vacuum = AsyncMock()
+    with (
+        patch.object(post_processors, "_load_app_config", return_value=cfg),
+        patch.object(post_processors, "HaikuRAGApp", return_value=app) as app_cls,
+    ):
+        await post_processors.vacuum("my source")
+
+    # DB resolved from the slugified source under $LANCEDB_DIR.
+    kwargs = app_cls.call_args.kwargs
+    assert isinstance(kwargs["db_path"], Path)
+    assert kwargs["db_path"].name == "my-source.lancedb"
+    assert kwargs["config"] is cfg
+    # Default retention is forced to 0 (reclaim everything).
+    assert cfg.storage.vacuum_retention_seconds == 0
+    app.vacuum.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_vacuum_custom_retention(lancedb_env):
+    cfg = _fake_config()
+    app = MagicMock()
+    app.vacuum = AsyncMock()
+    with (
+        patch.object(post_processors, "_load_app_config", return_value=cfg),
+        patch.object(post_processors, "HaikuRAGApp", return_value=app),
+    ):
+        await post_processors.vacuum("src", vacuum_retention_seconds=3600)
+
+    assert cfg.storage.vacuum_retention_seconds == 3600
+    app.vacuum.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_vacuum_none_retention_leaves_config_unchanged(lancedb_env):
+    cfg = _fake_config(retention=42)
+    app = MagicMock()
+    app.vacuum = AsyncMock()
+    with (
+        patch.object(post_processors, "_load_app_config", return_value=cfg),
+        patch.object(post_processors, "HaikuRAGApp", return_value=app),
+    ):
+        await post_processors.vacuum("src", vacuum_retention_seconds=None)
+
+    assert cfg.storage.vacuum_retention_seconds == 42  # not overridden
+    app.vacuum.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_vacuum_passes_config_path_through(lancedb_env):
+    cfg = _fake_config()
+    app = MagicMock()
+    app.vacuum = AsyncMock()
+    with (
+        patch.object(post_processors, "_load_app_config", return_value=cfg) as load_cfg,
+        patch.object(post_processors, "HaikuRAGApp", return_value=app),
+    ):
+        await post_processors.vacuum("src", config="/etc/haiku/haiku.rag.yaml")
+
+    load_cfg.assert_called_once_with("/etc/haiku/haiku.rag.yaml")


### PR DESCRIPTION
# Add manifest post-process callbacks

## Summary

Adds a `post_process` section to a manifest's `config` block: an ordered list of
callbacks invoked **after** the `haiku-ingester` load for that source completes
successfully (and after its summary output has been streamed). Each callback is
invoked as `method(source, **kwargs)`, where `method` is a dotted import path
and `kwargs` are the configured extra args.

This lets a manifest run per-source maintenance and enrichment automatically
right after a load — e.g. vacuuming the LanceDB or backfilling sidecar metadata 
and running document identification. The mechanism is generic: any importable
`method(source, **kwargs)` callable can be listed.

The change is **additive and backward-compatible** — `post_process` defaults to
an empty list, so existing manifests and loads are unaffected.

## What changed

- **Config** (`config.py`): new `PostProcessStep{method, kwargs}` model and
  `ManifestConfig.post_process: list[PostProcessStep]` (default empty).
- **Runner** (`manifest/post_process.py`, new): `run_post_process(manifest)`
  resolves each dotted-path method (`pkg.mod:func` or `pkg.mod.func`) and runs
  the steps **in order**.
- **Load hook** (`manifest/haiku_loader.py`): `run_load` invokes
  `run_post_process` at the end, gated on `returncode == 0`, and includes the
  per-step outcomes under a new `post_process` key in its result. Because both
  the CLI (`runner.run_manifests`) and the server (`server/haiku_queue`) paths
  funnel through `run_load`, both get post-processing from this single hook.
- **Built-in processor** (`manifest/post_processors.py`, new): `vacuum` runs
  LanceDB maintenance (optimize + clean up table history) on the per-source
  database via a `haiku.rag.app.HaikuRAGApp` instance, defaulting the retention
  window to `0` (reclaim everything). 
- **Docs**: README gains a "Post-process callbacks" section and a
  `config.post_process` entry; `docs/post-process-plan.md` is the design record.

## Behavior & design decisions

- **Runs only after a successful load.** Post-process is skipped on a non-zero
  exit, a timeout, or when the load is skipped (`--no-load`) — the DB may be
  incomplete otherwise.
- **Ordered, sequential** execution in the order listed.
- **Config auto-inject.** When a step omits `config` and the callable accepts
  one (an explicit `config` parameter or `**kwargs`), the manifest's resolved
  haiku config path (`resolve_haiku_cfg`) is passed, so a callback opens the
  store with the same config the load used (embedder must match). This keeps the
  `method(source, **kwargs)` contract while closing the per-manifest
  `haiku_config` gap.
- **Failure isolation.** A step that raises is logged and recorded with
  `ok=False`; the remaining steps still run (mirrors `run_load`'s lenient
  handling of load failures).

## Example

```yaml
config:
  haiku_config: haiku.rag.custom.yaml
  post_process:
    - method: soliplex.agents.manifest.post_processors:vacuum
      kwargs: { vacuum_retention_seconds: 0 }
    - method: your_project.postprocess:identify_and_apply
      kwargs: { only_missing: true, overrides: /etc/ingestion/overrides.json }
```

## Testing

- `tests/unit/test_post_process.py` — dotted-path resolution (`:` and `.`
  forms), `_wants_config`, ordered sync/async execution, config auto-inject
  on/off, and failure isolation (a failing step is recorded and later steps
  still run).
- `tests/unit/test_haiku_loader.py` — post-process runs on `returncode == 0`
  and is skipped on a non-zero exit.
- `tests/unit/test_manifest_models.py` — `PostProcessStep` / `post_process`
  parsing and defaults.
- `tests/unit/test_post_processors.py` — the `vacuum` processor (db resolution,
  retention override / default / left-unchanged, `HaikuRAGApp.vacuum` mocked).

Full suite: **925 passed, 100% branch coverage**; `ruff check` / `ruff format`
clean.


