### PR TITLE
Post process fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,11 +782,11 @@ invocation with `si-agent manifest run <path> --load` / `--no-load`.
 #### Post-process callbacks
 
 A manifest's `config.post_process` is an ordered list of callbacks invoked
-**after** the haiku-rag load for that source completes successfully (and after
-its summary has been streamed). Each entry names a `method` (a dotted import
-path) and optional `kwargs`; the callback is invoked as
-`method(source, **kwargs)` — `source` is the manifest's source and `kwargs`
-are the configured extra args.
+**after** the haiku-rag load for that source finishes (and after its summary
+has been streamed) — **whether the load succeeded, failed, or timed out**. Each
+entry names a `method` (a dotted import path) and optional `kwargs`; the
+callback is invoked as `method(source, **kwargs)` — `source` is the manifest's
+source and `kwargs` are the configured extra args.
 
 ```yaml
 config:
@@ -804,12 +804,19 @@ config:
 - **Config auto-inject:** when a step omits `config` and the callable accepts
   one (an explicit `config` parameter or `**kwargs`), the manifest's resolved
   haiku config path is passed so the callback opens the store with the same
-  config the load used.
+  config the load used. While the callbacks run, `SOURCE` and `DOWNLOAD_DIR` are
+  set in the environment (as they are for the load subprocess), so a config that
+  interpolates `${SOURCE}` / `${DOWNLOAD_DIR}` loads in-process too. Other
+  `${VAR}` references must be present in the inherited environment.
+- **Load outcome (`ingester_exit_code`):** callbacks fire regardless of the
+  load result. The load's exit code (`0` on success, non-zero on failure,
+  `None` on timeout) is auto-injected as an `ingester_exit_code` kwarg for
+  callables that accept one, so a step can decide what to do on failure.
 - **Failure isolation:** a step that raises is logged and recorded; the
   remaining steps still run. The per-step outcomes are returned under the load
   result's `post_process` key.
-- **Only after a successful load:** post-process does not run when the load
-  fails, times out, or is skipped (`--no-load`).
+- **Requires a load:** post-process only runs when a load runs — it is skipped
+  with `--no-load`.
 
 Built-in callback: `soliplex.agents.manifest.post_processors:vacuum` runs
 LanceDB maintenance (optimize + clean up table history) on the per-source

--- a/README.md
+++ b/README.md
@@ -812,9 +812,11 @@ config:
   load result. The load's exit code (`0` on success, non-zero on failure,
   `None` on timeout) is auto-injected as an `ingester_exit_code` kwarg for
   callables that accept one, so a step can decide what to do on failure.
-- **Failure isolation:** a step that raises is logged and recorded; the
-  remaining steps still run. The per-step outcomes are returned under the load
-  result's `post_process` key.
+- **Terminate on error:** a step that raises is logged and the exception
+  propagates — the remaining steps do **not** run. The per-step outcomes are
+  returned under the load result's `post_process` key only when every step
+  succeeds. In a batch/directory run the failure is isolated to that manifest
+  (recorded as `haiku_load_error` on its result); the other manifests still run.
 - **Requires a load:** post-process only runs when a load runs — it is skipped
   with `--no-load`.
 

--- a/src/soliplex/agents/manifest/haiku_loader.py
+++ b/src/soliplex/agents/manifest/haiku_loader.py
@@ -134,6 +134,19 @@ async def _pump_stream(reader, log, source: str) -> str:
     return "\n".join(lines)
 
 
+async def _run_post_process(manifest: Manifest, ingester_exit_code: int | None) -> list[dict]:
+    """Run the manifest's post-process callbacks after a load.
+
+    Fires regardless of the load outcome (success, failure, or timeout);
+    ``ingester_exit_code`` is the load's exit code (``None`` on timeout) and is
+    forwarded to the callbacks. The local import avoids a circular import
+    (``post_process`` imports ``resolve_haiku_cfg`` from this module).
+    """
+    from soliplex.agents.manifest import post_process
+
+    return await post_process.run_post_process(manifest, ingester_exit_code=ingester_exit_code)
+
+
 async def run_load(manifest: Manifest) -> dict:
     """Run a single haiku-rag batch load for *manifest*.
 
@@ -189,7 +202,13 @@ async def run_load(manifest: Manifest) -> dict:
             source,
             settings.haiku_load_timeout,
         )
-        return {"source": source, "db": db, "returncode": None, "timed_out": True}
+        return {
+            "source": source,
+            "db": db,
+            "returncode": None,
+            "timed_out": True,
+            "post_process": await _run_post_process(manifest, None),
+        }
 
     logger.info(
         "haiku load subprocess for source '%s' exited with code %s",
@@ -217,14 +236,6 @@ async def run_load(manifest: Manifest) -> dict:
             source,
             proc.returncode,
         )
-    post_process_results: list[dict] = []
-    if proc.returncode == 0 and manifest.config and manifest.config.post_process:
-        # Local import avoids a circular import (post_process imports
-        # resolve_haiku_cfg from this module).
-        from soliplex.agents.manifest import post_process
-
-        post_process_results = await post_process.run_post_process(manifest)
-
     return {
         "source": source,
         "db": db,
@@ -232,5 +243,5 @@ async def run_load(manifest: Manifest) -> dict:
         "stdout": out,
         "stderr": err,
         "timed_out": False,
-        "post_process": post_process_results,
+        "post_process": await _run_post_process(manifest, proc.returncode),
     }

--- a/src/soliplex/agents/manifest/post_process.py
+++ b/src/soliplex/agents/manifest/post_process.py
@@ -20,10 +20,14 @@ See ``docs/post-process-plan.md``.
 import importlib
 import inspect
 import logging
+import os
 from collections.abc import Callable
+from contextlib import contextmanager
 from inspect import Parameter
 
 from soliplex.agents.config import Manifest
+from soliplex.agents.config import settings
+from soliplex.agents.local_store import sanitize_source
 from soliplex.agents.manifest.haiku_loader import resolve_haiku_cfg
 
 logger = logging.getLogger(__name__)
@@ -42,19 +46,57 @@ def _resolve_method(spec: str) -> Callable:
     return getattr(module, attr)
 
 
-def _wants_config(method: Callable) -> bool:
-    """Whether ``method`` accepts a ``config`` keyword (named or via ``**kwargs``)."""
+def _accepts_kwarg(method: Callable, name: str) -> bool:
+    """Whether ``method`` accepts ``name`` as a keyword (named or via ``**kwargs``)."""
     try:
         params = inspect.signature(method).parameters
     except (TypeError, ValueError):  # pragma: no cover - builtins without signatures
         return False
-    if "config" in params:
+    if name in params:
         return True
     return any(p.kind is Parameter.VAR_KEYWORD for p in params.values())
 
 
-async def run_post_process(manifest: Manifest) -> list[dict]:
+@contextmanager
+def _load_env(manifest: Manifest):
+    """Temporarily expose the env vars ``run_load`` injects into the load
+    subprocess (``SOURCE`` / ``DOWNLOAD_DIR``).
+
+    In-process callbacks load the same haiku config the load used, and that
+    config interpolates ``${SOURCE}`` / ``${DOWNLOAD_DIR}`` (which
+    ``load_yaml_config`` expands eagerly). Those two are only ever set in the
+    subprocess env, so mirror them here for the duration of the callbacks. Other
+    ``${VAR}`` references (``STATE_DIR``, embedder URLs, ...) are expected in the
+    inherited environment, exactly as they are for the subprocess. Loads are
+    serialized, so the temporary global mutation does not race.
+    """
+    overrides = {
+        "SOURCE": sanitize_source(manifest.source),
+        "DOWNLOAD_DIR": settings.download_dir,
+    }
+    previous = {key: os.environ.get(key) for key in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def run_post_process(
+    manifest: Manifest,
+    *,
+    ingester_exit_code: int | None = None,
+) -> list[dict]:
     """Run ``manifest.config.post_process`` callbacks in order.
+
+    ``ingester_exit_code`` is the haiku-ingester load's exit code (``None`` on
+    timeout). Callbacks run regardless of it, so a step can inspect the outcome;
+    it is auto-injected as an ``ingester_exit_code`` kwarg for callables that
+    accept one.
 
     Returns a per-step outcome list of ``{"method", "ok", "error"}`` dicts. A
     step that raises is logged and recorded with ``ok=False``; execution
@@ -64,29 +106,32 @@ async def run_post_process(manifest: Manifest) -> list[dict]:
         return []
 
     results: list[dict] = []
-    for step in manifest.config.post_process:
-        outcome: dict = {"method": step.method, "ok": True, "error": None}
-        try:
-            method = _resolve_method(step.method)
-            kwargs = dict(step.kwargs)
-            if "config" not in kwargs and _wants_config(method):
-                kwargs["config"] = resolve_haiku_cfg(manifest)
-            logger.info(
-                "Running post-process '%s' for source '%s'",
-                step.method,
-                manifest.source,
-            )
-            value = method(manifest.source, **kwargs)
-            if inspect.isawaitable(value):
-                await value
-            logger.info("Post-process '%s' completed", step.method)
-        except Exception as exc:
-            logger.exception(
-                "Post-process '%s' failed for source '%s'",
-                step.method,
-                manifest.source,
-            )
-            outcome["ok"] = False
-            outcome["error"] = str(exc)
-        results.append(outcome)
+    with _load_env(manifest):
+        for step in manifest.config.post_process:
+            outcome: dict = {"method": step.method, "ok": True, "error": None}
+            try:
+                method = _resolve_method(step.method)
+                kwargs = dict(step.kwargs)
+                if "config" not in kwargs and _accepts_kwarg(method, "config"):
+                    kwargs["config"] = resolve_haiku_cfg(manifest)
+                if "ingester_exit_code" not in kwargs and _accepts_kwarg(method, "ingester_exit_code"):
+                    kwargs["ingester_exit_code"] = ingester_exit_code
+                logger.info(
+                    "Running post-process '%s' for source '%s'",
+                    step.method,
+                    manifest.source,
+                )
+                value = method(manifest.source, **kwargs)
+                if inspect.isawaitable(value):
+                    await value
+                logger.info("Post-process '%s' completed", step.method)
+            except Exception as exc:
+                logger.exception(
+                    "Post-process '%s' failed for source '%s'",
+                    step.method,
+                    manifest.source,
+                )
+                outcome["ok"] = False
+                outcome["error"] = str(exc)
+            results.append(outcome)
     return results

--- a/src/soliplex/agents/manifest/post_process.py
+++ b/src/soliplex/agents/manifest/post_process.py
@@ -98,9 +98,10 @@ async def run_post_process(
     it is auto-injected as an ``ingester_exit_code`` kwarg for callables that
     accept one.
 
-    Returns a per-step outcome list of ``{"method", "ok", "error"}`` dicts. A
-    step that raises is logged and recorded with ``ok=False``; execution
-    continues with the next step.
+    Runs the steps in order and **terminates on the first error**: a step that
+    raises is logged and the exception propagates, so the remaining steps do not
+    run. Returns a per-step ``{"method", "ok", "error"}`` list (all ``ok``) only
+    when every step succeeds.
     """
     if manifest.config is None or not manifest.config.post_process:
         return []
@@ -108,7 +109,11 @@ async def run_post_process(
     results: list[dict] = []
     with _load_env(manifest):
         for step in manifest.config.post_process:
-            outcome: dict = {"method": step.method, "ok": True, "error": None}
+            logger.info(
+                "Running post-process '%s' for source '%s'",
+                step.method,
+                manifest.source,
+            )
             try:
                 method = _resolve_method(step.method)
                 kwargs = dict(step.kwargs)
@@ -116,22 +121,16 @@ async def run_post_process(
                     kwargs["config"] = resolve_haiku_cfg(manifest)
                 if "ingester_exit_code" not in kwargs and _accepts_kwarg(method, "ingester_exit_code"):
                     kwargs["ingester_exit_code"] = ingester_exit_code
-                logger.info(
-                    "Running post-process '%s' for source '%s'",
-                    step.method,
-                    manifest.source,
-                )
                 value = method(manifest.source, **kwargs)
                 if inspect.isawaitable(value):
                     await value
-                logger.info("Post-process '%s' completed", step.method)
-            except Exception as exc:
+            except Exception:
                 logger.exception(
-                    "Post-process '%s' failed for source '%s'",
+                    "Post-process '%s' failed for source '%s'; terminating",
                     step.method,
                     manifest.source,
                 )
-                outcome["ok"] = False
-                outcome["error"] = str(exc)
-            results.append(outcome)
+                raise
+            logger.info("Post-process '%s' completed", step.method)
+            results.append({"method": step.method, "ok": True, "error": None})
     return results

--- a/src/soliplex/agents/manifest/runner.py
+++ b/src/soliplex/agents/manifest/runner.py
@@ -405,6 +405,11 @@ async def run_manifests(path: str, load: bool = False) -> list[dict]:
         path: Path to a single YAML file or directory of YAML files.
         load: Run a haiku-rag load after each manifest.
 
+    A failure while running or loading one manifest is isolated to that
+    manifest: it is logged and recorded (an ``error`` on the result, or a
+    ``haiku_load_error`` when the load/post-process step is the one that failed)
+    and the remaining manifests still run.
+
     Returns:
         List of per-manifest result dicts.
 
@@ -421,10 +426,19 @@ async def run_manifests(path: str, load: bool = False) -> list[dict]:
         manifests = load_manifests_from_dir(path)
     results = []
     for manifest in manifests:
-        result = await run_manifest(manifest)
+        try:
+            result = await run_manifest(manifest)
+        except Exception as e:
+            logger.exception("Manifest '%s' (%s) failed", manifest.id, manifest.name)
+            results.append({"manifest_id": manifest.id, "manifest_name": manifest.name, "error": str(e)})
+            continue
         if load:
             from soliplex.agents.manifest import haiku_loader
 
-            result["haiku_load"] = await haiku_loader.run_load(manifest)
+            try:
+                result["haiku_load"] = await haiku_loader.run_load(manifest)
+            except Exception as e:
+                logger.exception("haiku load failed for manifest '%s' (%s)", manifest.id, manifest.name)
+                result["haiku_load_error"] = str(e)
         results.append(result)
     return results

--- a/src/soliplex/agents/manifest/runner.py
+++ b/src/soliplex/agents/manifest/runner.py
@@ -379,11 +379,13 @@ async def run_manifest(manifest: Manifest) -> dict:
 
     error_count = sum(1 for r in results if "error" in r)
     deleted_count = len(delete_stale_result or [])
+    not_found_count = len(all_not_found)
     logger.info(
-        "Manifest '%s' finished: %d components, %d errors, %d deleted",
+        "Manifest '%s' finished: %d components, %d errors, %d not found (404), %d deleted",
         manifest.id,
         len(results),
         error_count,
+        not_found_count,
         deleted_count,
     )
 

--- a/tests/unit/test_haiku_loader.py
+++ b/tests/unit/test_haiku_loader.py
@@ -253,15 +253,19 @@ class TestRunLoad:
         assert result["timed_out"] is True
         assert result["returncode"] is None
 
-    @pytest.mark.asyncio
-    async def test_post_process_runs_on_success(self, haiku_env):
-        manifest = Manifest(
+    @staticmethod
+    def _pp_manifest():
+        return Manifest(
             id="m",
             name="M",
             source="src",
             config=ManifestConfig(post_process=[PostProcessStep(method="pkg:fn")]),
             components=[{"type": "fs", "name": "c", "path": "/data"}],
         )
+
+    @pytest.mark.asyncio
+    async def test_post_process_runs_on_success(self, haiku_env):
+        manifest = self._pp_manifest()
         proc = _fake_proc(returncode=0)
         with (
             patch(
@@ -276,18 +280,13 @@ class TestRunLoad:
             ) as mock_pp,
         ):
             result = await haiku_loader.run_load(manifest)
-        mock_pp.assert_awaited_once_with(manifest)
+        mock_pp.assert_awaited_once_with(manifest, ingester_exit_code=0)
         assert result["post_process"] == [{"method": "pkg:fn", "ok": True, "error": None}]
 
     @pytest.mark.asyncio
-    async def test_post_process_skipped_on_nonzero(self, haiku_env):
-        manifest = Manifest(
-            id="m",
-            name="M",
-            source="src",
-            config=ManifestConfig(post_process=[PostProcessStep(method="pkg:fn")]),
-            components=[{"type": "fs", "name": "c", "path": "/data"}],
-        )
+    async def test_post_process_runs_on_nonzero_with_exit_code(self, haiku_env):
+        # Fires even when the load failed; the exit code is forwarded.
+        manifest = self._pp_manifest()
         proc = _fake_proc(returncode=1, stdout_lines=[], stderr_lines=[b"x\n"])
         with (
             patch(
@@ -298,8 +297,34 @@ class TestRunLoad:
             patch(
                 "soliplex.agents.manifest.post_process.run_post_process",
                 new_callable=AsyncMock,
+                return_value=[{"method": "pkg:fn", "ok": True, "error": None}],
             ) as mock_pp,
         ):
             result = await haiku_loader.run_load(manifest)
-        mock_pp.assert_not_awaited()
-        assert result["post_process"] == []
+        mock_pp.assert_awaited_once_with(manifest, ingester_exit_code=1)
+        assert result["post_process"] == [{"method": "pkg:fn", "ok": True, "error": None}]
+
+    @pytest.mark.asyncio
+    async def test_post_process_runs_on_timeout_with_none_exit_code(self, haiku_env):
+        manifest = self._pp_manifest()
+        proc = _fake_proc(returncode=0)
+        with (
+            patch(
+                "soliplex.agents.manifest.haiku_loader.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ),
+            patch(
+                "soliplex.agents.manifest.haiku_loader.asyncio.timeout",
+                _RaisingTimeout,
+            ),
+            patch(
+                "soliplex.agents.manifest.post_process.run_post_process",
+                new_callable=AsyncMock,
+                return_value=[{"method": "pkg:fn", "ok": True, "error": None}],
+            ) as mock_pp,
+        ):
+            result = await haiku_loader.run_load(manifest)
+        mock_pp.assert_awaited_once_with(manifest, ingester_exit_code=None)
+        assert result["timed_out"] is True
+        assert result["post_process"] == [{"method": "pkg:fn", "ok": True, "error": None}]

--- a/tests/unit/test_manifest_runner.py
+++ b/tests/unit/test_manifest_runner.py
@@ -706,6 +706,54 @@ class TestRunManifests:
         assert results[0]["haiku_load"] == {"source": "src", "returncode": 0}
 
     @pytest.mark.asyncio
+    async def test_manifest_failure_isolated_to_that_manifest(self, tmp_path):
+        for name, mid in [("a.yml", "a"), ("b.yml", "b")]:
+            (tmp_path / name).write_text(
+                textwrap.dedent(f"""\
+                id: {mid}
+                name: M{mid}
+                source: src
+                components:
+                  - type: fs
+                    name: c
+                    path: /data
+            """)
+            )
+        with patch("soliplex.agents.manifest.runner.run_manifest", new_callable=AsyncMock) as mock:
+            mock.side_effect = [RuntimeError("boom"), {"manifest_id": "b", "results": []}]
+            results = await runner.run_manifests(str(tmp_path))
+        # First manifest failed, but the second still ran.
+        assert len(results) == 2
+        assert results[0] == {"manifest_id": "a", "manifest_name": "Ma", "error": "boom"}
+        assert results[1]["manifest_id"] == "b"
+
+    @pytest.mark.asyncio
+    async def test_haiku_load_failure_isolated(self, tmp_path):
+        f = tmp_path / "test.yml"
+        f.write_text(
+            textwrap.dedent("""\
+            id: test
+            name: Test
+            source: src
+            components:
+              - type: fs
+                name: c
+                path: /data
+        """)
+        )
+        with (
+            patch("soliplex.agents.manifest.runner.run_manifest", new_callable=AsyncMock) as mock_run,
+            patch("soliplex.agents.manifest.haiku_loader.run_load", new_callable=AsyncMock) as mock_load,
+        ):
+            mock_run.return_value = {"manifest_id": "test", "results": []}
+            mock_load.side_effect = RuntimeError("load boom")
+            results = await runner.run_manifests(str(f), load=True)
+        # Component result preserved; the load failure is recorded, not raised.
+        assert results[0]["manifest_id"] == "test"
+        assert results[0]["haiku_load_error"] == "load boom"
+        assert "haiku_load" not in results[0]
+
+    @pytest.mark.asyncio
     async def test_nonexistent_path(self):
         with pytest.raises(FileNotFoundError, match="not found"):
             await runner.run_manifests("/nonexistent/path")

--- a/tests/unit/test_manifest_runner.py
+++ b/tests/unit/test_manifest_runner.py
@@ -853,7 +853,7 @@ class TestRunManifestDeleteStale:
         assert result["delete_stale_result"] == []
 
     @pytest.mark.asyncio
-    async def test_not_found_excluded_from_reconcile_set(self, delete_stale_manifest):
+    async def test_not_found_excluded_from_reconcile_set(self, delete_stale_manifest, caplog):
         # A 404'd URI is reported in not_found and must be subtracted from the
         # reconcile "should exist" set so its local copy is removed.
         fs_result = {
@@ -870,12 +870,15 @@ class TestRunManifestDeleteStale:
                 {FSComponent: AsyncMock(return_value=fs_result), WebComponent: AsyncMock(return_value=web_result)},
             ),
             patch("soliplex.agents.manifest.runner.local_state.reconcile_documents") as mock_check,
+            caplog.at_level(logging.INFO, logger="soliplex.agents.manifest.runner"),
         ):
             mock_check.return_value = []
             await runner.run_manifest(delete_stale_manifest)
 
         mock_check.assert_called_once()
         assert mock_check.call_args[0][1] == {"a.md", "http://example.com"}
+        # The completion summary reports the 404 count.
+        assert "1 not found (404)" in caplog.text
 
     @pytest.mark.asyncio
     async def test_not_found_does_not_block_reconcile(self, delete_stale_manifest):

--- a/tests/unit/test_post_process.py
+++ b/tests/unit/test_post_process.py
@@ -32,25 +32,25 @@ def test_resolve_method_dotted():
     assert post_process._resolve_method("os.getcwd") is os.getcwd
 
 
-# --- _wants_config ---
+# --- _accepts_kwarg ---
 
 
-def test_wants_config_named_param():
+def test_accepts_kwarg_named_param():
     def method(source, *, config=None): ...
 
-    assert post_process._wants_config(method) is True
+    assert post_process._accepts_kwarg(method, "config") is True
 
 
-def test_wants_config_var_keyword():
+def test_accepts_kwarg_var_keyword():
     def method(source, **kwargs): ...
 
-    assert post_process._wants_config(method) is True
+    assert post_process._accepts_kwarg(method, "anything") is True
 
 
-def test_wants_config_absent():
+def test_accepts_kwarg_absent():
     def method(source, *, x=1): ...
 
-    assert post_process._wants_config(method) is False
+    assert post_process._accepts_kwarg(method, "config") is False
 
 
 # --- run_post_process ---
@@ -94,11 +94,39 @@ async def test_runs_in_order_with_inject_and_sync_async(monkeypatch):
     assert [r["ok"] for r in results] == [True, True, True, True]
     assert all(r["error"] is None for r in results)
     assert calls == [
-        ("async", "s1", {"config": "CFG"}),
+        # **kwargs accepts both config and ingester_exit_code -> both injected
+        ("async", "s1", {"config": "CFG", "ingester_exit_code": None}),
         ("sync", "s1", {"config": "CFG", "x": 1}),
         ("sync", "s1", {"config": "OWN", "x": 2}),
         ("noconf", "s1", {"y": None}),
     ]
+
+
+@pytest.mark.asyncio
+async def test_injects_ingester_exit_code_when_accepted(monkeypatch):
+    calls: list[tuple] = []
+
+    def wants_code(source, *, ingester_exit_code=None):
+        calls.append(("named", ingester_exit_code))
+
+    def wants_kwargs(source, **kwargs):
+        calls.append(("kwargs", kwargs.get("ingester_exit_code")))
+
+    def no_code(source, *, x=None):  # no exit-code param, no **kwargs -> no inject
+        calls.append(("none", x))
+
+    registry = {"a": wants_code, "b": wants_kwargs, "c": no_code}
+    monkeypatch.setattr(post_process, "_resolve_method", lambda spec: registry[spec])
+    monkeypatch.setattr(post_process, "resolve_haiku_cfg", lambda manifest: "CFG")
+
+    steps = [
+        PostProcessStep(method="a"),
+        PostProcessStep(method="b"),
+        PostProcessStep(method="c"),
+    ]
+    await post_process.run_post_process(_manifest(steps=steps), ingester_exit_code=2)
+
+    assert calls == [("named", 2), ("kwargs", 2), ("none", None)]
 
 
 @pytest.mark.asyncio
@@ -122,3 +150,28 @@ async def test_failing_step_is_logged_and_others_continue(monkeypatch):
     assert "nope" in results[0]["error"]
     assert results[1]["ok"] is True
     assert ran == ["src"]  # the step after the failure still ran
+
+
+# --- _load_env ---
+
+
+def test_load_env_sets_and_restores(monkeypatch):
+    # SOURCE preexists (restored to old value); DOWNLOAD_DIR is unset (popped).
+    monkeypatch.setenv("SOURCE", "preexisting")
+    monkeypatch.delenv("DOWNLOAD_DIR", raising=False)
+    monkeypatch.setattr(post_process.settings, "download_dir", "downloads", raising=False)
+
+    with post_process._load_env(_manifest(source="army-airfield")):
+        assert os.environ["SOURCE"] == "army-airfield"
+        assert os.environ["DOWNLOAD_DIR"] == "downloads"
+
+    assert os.environ["SOURCE"] == "preexisting"  # restored
+    assert "DOWNLOAD_DIR" not in os.environ  # popped
+
+
+def test_load_env_sanitizes_source(monkeypatch):
+    monkeypatch.delenv("SOURCE", raising=False)
+    monkeypatch.setattr(post_process.settings, "download_dir", "downloads", raising=False)
+
+    with post_process._load_env(_manifest(source="gitea:admin:repo")):
+        assert os.environ["SOURCE"] == "gitea_admin_repo"  # ':' -> '_'

--- a/tests/unit/test_post_process.py
+++ b/tests/unit/test_post_process.py
@@ -130,26 +130,26 @@ async def test_injects_ingester_exit_code_when_accepted(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_failing_step_is_logged_and_others_continue(monkeypatch):
+async def test_failing_step_terminates_and_skips_rest(monkeypatch):
     ran: list[str] = []
 
     def boom(source, **kwargs):
         raise RuntimeError("nope")
 
-    def ok(source, **kwargs):
+    def later(source, **kwargs):
         ran.append(source)
 
-    registry = {"boom": boom, "ok": ok}
+    registry = {"boom": boom, "later": later}
     monkeypatch.setattr(post_process, "_resolve_method", lambda spec: registry[spec])
     monkeypatch.setattr(post_process, "resolve_haiku_cfg", lambda manifest: "CFG")
 
-    steps = [PostProcessStep(method="boom"), PostProcessStep(method="ok")]
-    results = await post_process.run_post_process(_manifest(steps=steps))
+    steps = [PostProcessStep(method="boom"), PostProcessStep(method="later")]
 
-    assert results[0]["ok"] is False
-    assert "nope" in results[0]["error"]
-    assert results[1]["ok"] is True
-    assert ran == ["src"]  # the step after the failure still ran
+    # The error propagates (terminate on error) rather than being swallowed.
+    with pytest.raises(RuntimeError, match="nope"):
+        await post_process.run_post_process(_manifest(steps=steps))
+
+    assert ran == []  # the step after the failure did not run
 
 
 # --- _load_env ---


### PR DESCRIPTION
# Post-process fixes: exit-code awareness, env passthrough, fail-fast, 404 logging

## Summary

Follow-up fixes to the manifest `config.post_process` callbacks added in #71,
found while wiring up the `vacuum` / `tag` / identify processors against real
manifests. Three related changes:

1. **Run post-process on any load outcome** and forward the load's exit code, so
   a callback can react to a failed/timed-out load.
2. **Make the post-process haiku config actually load in-process** by exposing
   the same `SOURCE` / `DOWNLOAD_DIR` the load subprocess gets.
3. **Fail fast, but isolate the failure to one manifest** — a raising callback
   terminates that manifest's post-process chain and is recorded, while the rest
   of a batch/directory run keeps going.
4. **Log the 404 count** in the per-manifest completion summary.

Builds on `main` (post-processing support, #71). Additive/behavioral only — no
config schema changes.

## What changed

### Run on any outcome + `ingester_exit_code` (`haiku_loader.py`, `post_process.py`)

- `run_load` now invokes post-process at the **end of the load and on the
  timeout path**, no longer gated on `returncode == 0`. A shared
  `_run_post_process(manifest, ingester_exit_code)` helper is called from both
  return sites (normal → `proc.returncode`, timeout → `None`).
- `run_post_process(manifest, *, ingester_exit_code=None)` auto-injects
  `ingester_exit_code` into callbacks that accept it (a named param or
  `**kwargs`), mirroring the existing `config` auto-inject. `_wants_config` was
  generalized to `_accepts_kwarg(method, name)`.

### In-process config env (`post_process.py`)

- The auto-injected haiku config interpolates `${SOURCE}` / `${DOWNLOAD_DIR}`,
  which `load_yaml_config` expands eagerly — but those are only set in the load
  **subprocess** env, so an in-process callback (e.g. `vacuum`) raised
  `MissingEnvVarError: ${SOURCE}`.
- A new `_load_env(manifest)` context manager temporarily sets `SOURCE`
  (`sanitize_source(source)`) and `DOWNLOAD_DIR` (`settings.download_dir`) around
  the callback loop — exactly what `run_load` gives the subprocess. Other
  `${VAR}`s (STATE_DIR, embedder URLs) come from the inherited env, as before.
  Loads are serialized, so the temporary global mutation does not race.

### Fail-fast, isolated per manifest (`post_process.py`, `runner.py`)

- `run_post_process` now **terminates on the first error**: the failing step is
  logged and the exception propagates, so remaining steps do not run (was:
  log-and-continue).
- `run_manifests` isolates that failure to the individual manifest: a raising
  `run_manifest` is recorded as `{manifest_id, manifest_name, error}` and skipped;
  a failing load/post-process is recorded as `haiku_load_error` on the manifest's
  result (component results preserved). Either way the remaining manifests in a
  directory run still execute, and the CLI no longer aborts the whole batch.

### 404 logging (`runner.py`)

- The manifest completion summary now includes the 404 count from
  `all_not_found`:
  `Manifest '<id>' finished: N components, N errors, N not found (404), N deleted`.

## Behavior notes

- Post-process still only runs when a load runs (skipped with `--no-load`).
- Callbacks that don't declare `ingester_exit_code` are unaffected and run
  regardless of outcome; declare the param (or `**kwargs`) to guard against
  acting on an incomplete DB after a failure/timeout.
- The server load worker already catches load exceptions; the isolation change
  makes the CLI/`run_manifests` path behave the same (one bad manifest ≠ whole
  batch).

## Testing

- `test_haiku_loader.py`: post-process runs on success (`exit_code=0`), on a
  non-zero exit (`=1`), and on timeout (`=None`).
- `test_post_process.py`: `_accepts_kwarg`; `ingester_exit_code` injected only
  where accepted; `_load_env` sets/restores `SOURCE`/`DOWNLOAD_DIR` (and
  sanitizes); a failing step propagates and later steps are skipped.
- `test_manifest_runner.py`: a failing manifest is isolated (others still run);
  a load failure is recorded as `haiku_load_error` without raising; the 404
  count appears in the completion summary.

Full suite: **931 passed, 100% branch coverage**; `ruff check` / `ruff format`
clean.

