### PR TITLE
move vacuum post-processor to sub-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ config:
   haiku_config: haiku.rag.custom.yaml
   post_process:
     - method: soliplex.agents.manifest.post_processors:vacuum
-      kwargs: { vacuum_retention_seconds: 0 }
+      kwargs: { timeout: 1800 }
     - method: your_project.postprocess:identify_and_apply
       kwargs: { only_missing: true, overrides: /etc/agent/overrides.json }
 ```
@@ -822,7 +822,11 @@ config:
 
 Built-in callback: `soliplex.agents.manifest.post_processors:vacuum` runs
 LanceDB maintenance (optimize + clean up table history) on the per-source
-database.
+database. It shells out to `haiku-rag vacuum` as a subprocess (like the load) —
+keeping LanceDB's async runtime out of the agent's event loop and making the
+pass killable via its `timeout` kwarg (default 1800s), so a stuck compaction
+can't hang the run. Retention comes from the haiku config's
+`storage.vacuum_retention_seconds`.
 
 **Note:** All commands support WebDAV credentials via environment variables (`WEBDAV_URL`, `WEBDAV_USERNAME`, `WEBDAV_PASSWORD`) or command-line options (`--webdav-url`, `--webdav-username`, `--webdav-password`).
 

--- a/src/soliplex/agents/manifest/post_processors.py
+++ b/src/soliplex/agents/manifest/post_processors.py
@@ -7,51 +7,80 @@ list by dotted path and invoked as ``method(source, **kwargs)`` after the
 ingester-agents.
 """
 
+import asyncio
 import logging
-from pathlib import Path
+import os
 
-from haiku.rag.app import HaikuRAGApp
-from haiku.rag.config import AppConfig
-from haiku.rag.config import get_config
-from haiku.rag.config import load_yaml_config
-
+from soliplex.agents.config import settings
+from soliplex.agents.local_store import sanitize_source
+from soliplex.agents.manifest.haiku_loader import _pump_stream
 from soliplex.agents.manifest.haiku_loader import resolve_db_path
 
 logger = logging.getLogger(__name__)
 
-
-def _load_app_config(config: str | None) -> AppConfig:
-    """Load an ``AppConfig`` from a path, or haiku's own config discovery."""
-    if config:
-        return AppConfig.model_validate(load_yaml_config(config))
-    return get_config()
+# Default upper bound (seconds) on a vacuum subprocess before it is killed.
+DEFAULT_VACUUM_TIMEOUT = 1800
 
 
 async def vacuum(
     source: str,
     *,
     config: str | None = None,
-    vacuum_retention_seconds: int | None = 0,
+    timeout: float = DEFAULT_VACUUM_TIMEOUT,
 ) -> None:
-    """Vacuum the per-source LanceDB (optimize + clean up table history).
+    """Vacuum the per-source LanceDB by running ``haiku-rag vacuum`` as a
+    subprocess.
 
-    A post-process callback: resolves the same ``${LANCEDB_DIR}/<slug>.lancedb``
-    the load wrote (via :func:`resolve_db_path`), opens a
-    :class:`~haiku.rag.app.HaikuRAGApp`, and runs its ``vacuum``.
+    Running out-of-process -- exactly like the ``haiku-ingester`` load -- keeps
+    LanceDB's async runtime out of the agent's event loop (avoiding an
+    in-process deadlock) and makes the pass killable, so a stuck compaction
+    cannot hang the run or leave the process unable to exit. The subprocess's
+    stdout/stderr are streamed to the logger line by line. Retention is taken
+    from the haiku config's ``storage.vacuum_retention_seconds``.
 
     Args:
         source: The manifest source; slugified to locate the database.
-        config: Optional haiku.rag config path. When omitted, the manifest's
-            resolved config is auto-injected by the post-process runner (or
-            haiku's own discovery is used). It must match the DB embedder.
-        vacuum_retention_seconds: Overrides the config's retention window before
-            vacuuming. Defaults to ``0`` -- reclaim everything
+        config: Optional haiku.rag config path (auto-injected by the
+            post-process runner). Passed as ``haiku-rag --config``; when omitted
+            the subprocess falls back to haiku's own config discovery. It must
+            match the DB embedder.
+        timeout: Seconds before the vacuum subprocess is killed.
+
+    Raises:
+        RuntimeError: if the vacuum times out or exits non-zero.
     """
-    db_path = Path(resolve_db_path(source))
-    app_config = _load_app_config(config)
-    if vacuum_retention_seconds is not None:
-        app_config.storage.vacuum_retention_seconds = vacuum_retention_seconds
+    db_path = resolve_db_path(source)
+    argv = ["haiku-rag"]
+    if config:
+        argv += ["--config", str(config)]
+    argv += ["vacuum", "--db", db_path]
+
+    # Mirror the load subprocess env so a config that interpolates ${SOURCE} /
+    # ${DOWNLOAD_DIR} resolves, and force unbuffered output for live streaming.
+    env = os.environ.copy()
+    env["SOURCE"] = sanitize_source(source)
+    env["DOWNLOAD_DIR"] = settings.download_dir
+    env["PYTHONUNBUFFERED"] = "1"
+
     logger.info("Vacuuming LanceDB for source '%s' -> %s", source, db_path)
-    app = HaikuRAGApp(db_path=db_path, config=app_config)
-    await app.vacuum()
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        async with asyncio.timeout(timeout):
+            await asyncio.gather(
+                _pump_stream(proc.stdout, logger.info, source),
+                _pump_stream(proc.stderr, logger.info, source),
+            )
+            await proc.wait()
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise RuntimeError(f"Vacuum for source '{source}' timed out after {timeout}s") from None
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"Vacuum for source '{source}' failed (rc={proc.returncode})")
     logger.info("Vacuum completed for source '%s'", source)

--- a/tests/unit/test_post_processors.py
+++ b/tests/unit/test_post_processors.py
@@ -1,7 +1,5 @@
 """Tests for built-in manifest post-process callbacks — 100% branch coverage."""
 
-from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -11,103 +9,100 @@ import pytest
 from soliplex.agents.config import settings
 from soliplex.agents.manifest import post_processors
 
+_EXEC = "soliplex.agents.manifest.post_processors.asyncio.create_subprocess_exec"
+_TIMEOUT = "soliplex.agents.manifest.post_processors.asyncio.timeout"
+
+
+class _FakeStream:
+    """Minimal async-iterable stand-in for asyncio.StreamReader."""
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0)
+
+
+def _fake_proc(returncode=0, stdout_lines=(b"ok\n",), stderr_lines=()):
+    proc = MagicMock()
+    proc.stdout = _FakeStream(stdout_lines)
+    proc.stderr = _FakeStream(stderr_lines)
+    proc.returncode = returncode
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+class _RaisingTimeout:
+    """asyncio.timeout stand-in that trips immediately on entry."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        raise TimeoutError
+
+    async def __aexit__(self, *args):
+        return False
+
 
 @pytest.fixture
 def lancedb_env(monkeypatch):
-    """Point the per-source DB resolver at a known base dir."""
     monkeypatch.setattr(settings, "lancedb_dir", "/data/lance", raising=False)
-
-
-# --- _load_app_config -----------------------------------------------------
-
-
-def test_load_app_config_from_path():
-    with (
-        patch.object(post_processors, "load_yaml_config", return_value={"k": "v"}) as load_yaml,
-        patch.object(post_processors.AppConfig, "model_validate", return_value="CFG") as validate,
-    ):
-        result = post_processors._load_app_config("cfg.yaml")
-
-    load_yaml.assert_called_once_with("cfg.yaml")
-    validate.assert_called_once_with({"k": "v"})
-    assert result == "CFG"
-
-
-def test_load_app_config_from_discovery():
-    with patch.object(post_processors, "get_config", return_value="DISCOVERED") as get_cfg:
-        result = post_processors._load_app_config(None)
-
-    get_cfg.assert_called_once_with()
-    assert result == "DISCOVERED"
-
-
-# --- vacuum ---------------------------------------------------------------
-
-
-def _fake_config(retention=999):
-    return SimpleNamespace(storage=SimpleNamespace(vacuum_retention_seconds=retention))
+    monkeypatch.setattr(settings, "download_dir", "downloads", raising=False)
 
 
 @pytest.mark.asyncio
-async def test_vacuum_resolves_db_forces_full_reclaim_and_runs(lancedb_env):
-    cfg = _fake_config()
-    app = MagicMock()
-    app.vacuum = AsyncMock()
-    with (
-        patch.object(post_processors, "_load_app_config", return_value=cfg),
-        patch.object(post_processors, "HaikuRAGApp", return_value=app) as app_cls,
-    ):
-        await post_processors.vacuum("my source")
+async def test_vacuum_runs_subprocess_with_config(lancedb_env):
+    proc = _fake_proc(returncode=0)
+    with patch(_EXEC, new_callable=AsyncMock, return_value=proc) as mock_exec:
+        await post_processors.vacuum("army-airfield", config="/etc/haiku/haiku.rag.yaml")
 
-    # DB resolved from the slugified source under $LANCEDB_DIR.
-    kwargs = app_cls.call_args.kwargs
-    assert isinstance(kwargs["db_path"], Path)
-    assert kwargs["db_path"].name == "my-source.lancedb"
-    assert kwargs["config"] is cfg
-    # Default retention is forced to 0 (reclaim everything).
-    assert cfg.storage.vacuum_retention_seconds == 0
-    app.vacuum.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_vacuum_custom_retention(lancedb_env):
-    cfg = _fake_config()
-    app = MagicMock()
-    app.vacuum = AsyncMock()
-    with (
-        patch.object(post_processors, "_load_app_config", return_value=cfg),
-        patch.object(post_processors, "HaikuRAGApp", return_value=app),
-    ):
-        await post_processors.vacuum("src", vacuum_retention_seconds=3600)
-
-    assert cfg.storage.vacuum_retention_seconds == 3600
-    app.vacuum.assert_awaited_once()
+    argv = list(mock_exec.call_args.args)
+    assert argv[0] == "haiku-rag"
+    assert "--config" in argv
+    assert "/etc/haiku/haiku.rag.yaml" in argv
+    assert argv[-2] == "--db"
+    # DB resolved to the slugified source under $LANCEDB_DIR.
+    assert argv[-1].replace("\\", "/").endswith("army-airfield.lancedb")
+    # Env carries SOURCE / DOWNLOAD_DIR so a config with ${SOURCE} resolves.
+    env = mock_exec.call_args.kwargs["env"]
+    assert env["SOURCE"] == "army-airfield"
+    assert env["DOWNLOAD_DIR"] == "downloads"
+    assert env["PYTHONUNBUFFERED"] == "1"
 
 
 @pytest.mark.asyncio
-async def test_vacuum_none_retention_leaves_config_unchanged(lancedb_env):
-    cfg = _fake_config(retention=42)
-    app = MagicMock()
-    app.vacuum = AsyncMock()
-    with (
-        patch.object(post_processors, "_load_app_config", return_value=cfg),
-        patch.object(post_processors, "HaikuRAGApp", return_value=app),
-    ):
-        await post_processors.vacuum("src", vacuum_retention_seconds=None)
+async def test_vacuum_omits_config_when_none(lancedb_env):
+    proc = _fake_proc(returncode=0)
+    with patch(_EXEC, new_callable=AsyncMock, return_value=proc) as mock_exec:
+        await post_processors.vacuum("src")
 
-    assert cfg.storage.vacuum_retention_seconds == 42  # not overridden
-    app.vacuum.assert_awaited_once()
+    assert "--config" not in mock_exec.call_args.args
 
 
 @pytest.mark.asyncio
-async def test_vacuum_passes_config_path_through(lancedb_env):
-    cfg = _fake_config()
-    app = MagicMock()
-    app.vacuum = AsyncMock()
-    with (
-        patch.object(post_processors, "_load_app_config", return_value=cfg) as load_cfg,
-        patch.object(post_processors, "HaikuRAGApp", return_value=app),
-    ):
-        await post_processors.vacuum("src", config="/etc/haiku/haiku.rag.yaml")
+async def test_vacuum_raises_on_nonzero_exit(lancedb_env):
+    proc = _fake_proc(returncode=2, stdout_lines=[], stderr_lines=[b"boom\n"])
+    with patch(_EXEC, new_callable=AsyncMock, return_value=proc):
+        with pytest.raises(RuntimeError, match="failed"):
+            await post_processors.vacuum("src")
 
-    load_cfg.assert_called_once_with("/etc/haiku/haiku.rag.yaml")
+
+@pytest.mark.asyncio
+async def test_vacuum_kills_and_raises_on_timeout(lancedb_env):
+    proc = _fake_proc(returncode=0)
+    with (
+        patch(_EXEC, new_callable=AsyncMock, return_value=proc),
+        patch(_TIMEOUT, _RaisingTimeout),
+    ):
+        with pytest.raises(RuntimeError, match="timed out"):
+            await post_processors.vacuum("src", timeout=1)
+
+    proc.kill.assert_called_once()
+    proc.wait.assert_awaited()


### PR DESCRIPTION
# Run the vacuum post-processor as a subprocess (fix in-process LanceDB hang)

## Summary

The built-in `vacuum` post-processor opened LanceDB **in-process** —
`HaikuRAGApp(db_path, config).vacuum()` — driving LanceDB's async runtime under
the agent's own event loop. In that mode the awaited `optimize()` future never
resolved: the main event loop parked in `select()` forever (confirmed by a
thread dump), the manifest run hung, and the process never exited (LanceDB's
`LanceDBBackgroundEventLoop`/tokio threads kept it alive).

This makes `vacuum` shell out to `haiku-rag vacuum` as a **subprocess**, exactly
like the load runs `haiku-ingester run-batch`. The child gets its own clean
`asyncio.run` and LanceDB lifecycle (no in-process async deadlock), its native
threads die when it exits (process can terminate), and the pass is **killable
on timeout** so a stuck compaction can't hang the run.

## What changed

`src/soliplex/agents/manifest/post_processors.py`

- `vacuum(source, *, config=None, timeout=1800)` now:
  - builds `argv = ["haiku-rag", ("--config", <cfg>)?, "vacuum", "--db", <db>]`
    (`<db>` from `resolve_db_path(source)`; `--config` only when provided);
  - runs it via `asyncio.create_subprocess_exec`, streaming stdout/stderr to the
    logger through the existing `_pump_stream`;
  - injects `SOURCE` / `DOWNLOAD_DIR` / `PYTHONUNBUFFERED` into the child env so a
    config that interpolates `${SOURCE}` / `${DOWNLOAD_DIR}` resolves;
  - wraps the wait in `asyncio.timeout(timeout)` and **kills** the process on
    timeout, raising `RuntimeError`; a non-zero exit also raises.
- Removed the in-process `HaikuRAGApp` / `_load_app_config` path entirely.

Behavioral notes:

- **Timeout kwarg replaces the retention kwarg.** The `haiku-rag vacuum` CLI has
  no retention flag, so retention now comes from the haiku config's
  `storage.vacuum_retention_seconds` (previously the callback forced `0`). Set
  that in the haiku config for aggressive reclamation.
- A killed/failed vacuum raises; combined with the existing terminate-on-error
  and per-manifest isolation, it fails only that manifest's post-process (logged
  as `haiku_load_error`) and the rest of a batch continues.

## Tests

`tests/unit/test_post_processors.py` rewritten to mock `create_subprocess_exec`
(mirroring `test_haiku_loader`): runs with config (argv + `--config` + resolved
`--db` + `SOURCE`/`DOWNLOAD_DIR` env), omits `--config` when `None`, raises on a
non-zero exit, and kills + raises on timeout.

Full suite: **939 passed, 100% branch coverage**; `ruff check` / `ruff format`
clean.

## Notes

- Complementary to the haiku.rag `storage.vacuum_timeout_seconds` change: the
  subprocess is the robust fix for the ingester; the haiku-side timeout protects
  any *other* in-process vacuum callers.
- Requires the `haiku-rag` console script on `PATH` (installed with
  `haiku-rag[ingester]`, same package that provides `haiku-ingester`).

